### PR TITLE
chore: upgrade to Go 1.27 and golangci-lint v2.13.2

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,5 +1,5 @@
 # Ensure that the version matches linter version in CI pipeline step at ".github/workflows/linter.yml".
-version: v2.7.1
+version: v2.13.2
 plugins:
   - module: 'github.com/amp-labs/connectors/tools/linters/nogoroutine'
     path: './tools/linters/nogoroutine'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         # git ls-remote https://github.com/actions/setup-go.git refs/tags/v7
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
-          go-version: "1.26.5"
+          go-version: "1.27.1"
           cache: false
 
       - name: Build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.27.1"
           cache: false
 
       - name: Generate go code
@@ -21,7 +21,7 @@ jobs:
         # Ensure that the linter version matches with ".custom-gcl.yml".
       - name: Install golangci-lint
         run: |
-          LINTER_VERSION="v2.7.1"
+          LINTER_VERSION="v2.13.2"
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin $LINTER_VERSION
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,8 +21,7 @@ jobs:
         # Ensure that the linter version matches with ".custom-gcl.yml".
       - name: Install golangci-lint
         run: |
-          LINTER_VERSION="v2.13.2"
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin $LINTER_VERSION
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Build custom golangci-lint with custom linters

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ linters:
     - depguard
     # Annoying and unhelpful. Assumes uninitialized (zero-valued) fields are always a bug, which is plain wrong.
     - exhaustruct
+    # Deprecated, replaced by exhaustruct_v5
+    - exhaustruct_v5
     # Disabled because we use inits all over the place
     - gochecknoinits
     # Marks [TODO, FIXME, BUG] comments as errors. We use these, so this is not helpful - unless we decide this is a good policy.
@@ -35,6 +37,8 @@ linters:
     - wrapcheck
     # Deprecated (since v2.2.0) due to: new major version. Replaced by wsl_v5.
     - wsl
+    # Deprecated, replaced by gomodguard_v2 (which is enabled via `default: all`)
+    - gomodguard
   settings:
     # https://golangci-lint.run/docs/linters/configuration/#revive
     revive:
@@ -109,6 +113,21 @@ linters:
       - linters:
           - gochecknoglobals
         path: ^subscribe/
+      # providers/ is a declarative catalog: each file describes one SaaS API.
+      # Two providers happening to share a literal (a header name, a content
+      # type) is a coincidence, not a shared concept, so hoisting constants
+      # would couple unrelated provider definitions. scripts/*/metadata is
+      # generated/scraped API metadata with the same property.
+      - linters:
+          - goconst
+        path: ^(providers|scripts)/
+      # providers/ declares the NAMES of auth headers and fields for each SaaS
+      # API, not secrets. G101 stays active everywhere else, where a real
+      # hardcoded credential could actually appear.
+      - linters:
+          - gosec
+        text: "G101"
+        path: ^providers/
     paths:
       - playground
       - test

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install/linters:
 	@echo "Installing gci..."
 	go install github.com/daixiang0/gci@latest
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "Installing typos..."
 	cargo install typos-cli
 	@echo "Linters installed successfully!"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ====================
 
 # Linter versions - keep in sync with .github/workflows/linter.yml
-GOLANGCI_LINT_VERSION=v2.7.1
+GOLANGCI_LINT_VERSION=v2.13.2
 
 # Install all linters required by make fix
 .PHONY: install/linters

--- a/common/error.go
+++ b/common/error.go
@@ -92,8 +92,7 @@ func (p ErrorPostProcessor) handleError(err error) error {
 // Any future errors that need to be converted to the in-house errors should be added here.
 // One important and widespread error is InvalidGrant which happens on invalid refresh token.
 func transformOauth2LibraryError(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		var oauthErr *oauth2.RetrieveError
 		if urlErr != nil && errors.As(urlErr.Err, &oauthErr) {
 			if oauthErr.ErrorCode == "invalid_grant" {

--- a/common/http.go
+++ b/common/http.go
@@ -34,6 +34,9 @@ const (
 	HeaderModeSetIfMissing
 )
 
+// redactedValue replaces the value of a sensitive header when logging.
+const redactedValue = "<redacted>"
+
 // Header is a key/value pair that can be added to a request.
 type Header struct {
 	Key   string     `json:"key"`
@@ -149,17 +152,17 @@ func redactSensitiveRequestHeaders(hdrs []Header) Headers {
 	for _, hdr := range hdrs {
 		switch {
 		case strings.EqualFold(hdr.Key, "Authorization"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		case strings.EqualFold(hdr.Key, "X-Shopify-Access-Token"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		case strings.EqualFold(hdr.Key, "Proxy-Authorization"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		case strings.EqualFold(hdr.Key, "x-amz-security-token"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		case strings.EqualFold(hdr.Key, "X-Api-Key"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		case strings.EqualFold(hdr.Key, "X-Admin-Key"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		default:
 			redacted = append(redacted, hdr)
 		}
@@ -178,7 +181,7 @@ func redactSensitiveResponseHeaders(hdrs []Header) Headers {
 	for _, hdr := range hdrs {
 		switch {
 		case strings.EqualFold(hdr.Key, "Set-Cookie"):
-			redacted = append(redacted, Header{Key: hdr.Key, Value: "<redacted>"})
+			redacted = append(redacted, Header{Key: hdr.Key, Value: redactedValue})
 		default:
 			redacted = append(redacted, hdr)
 		}

--- a/common/interpreter/responder.go
+++ b/common/interpreter/responder.go
@@ -26,8 +26,8 @@ type FaultyResponder struct {
 //     This is an optional map that will precede any default status to error mapping.
 func NewFaultyResponder(errorSwitch *FormatSwitch, statusCodeMap map[int]error) *FaultyResponder {
 	return &FaultyResponder{
-		errorSwitch:      errorSwitch,
-		StatusCodeMapper: StatusCodeMapper{Registry: statusCodeMap},
+		errorSwitch: errorSwitch,
+		Registry:    statusCodeMap,
 	}
 }
 
@@ -89,8 +89,8 @@ type XMLFaultyResponder struct {
 //     This is an optional map that will precede any default status to error mapping.
 func NewXMLFaultyResponder(templates Templates, statusCodeMap map[int]error) *XMLFaultyResponder {
 	return &XMLFaultyResponder{
-		templates:        templates,
-		StatusCodeMapper: StatusCodeMapper{Registry: statusCodeMap},
+		templates: templates,
+		Registry:  statusCodeMap,
 	}
 }
 

--- a/common/naming/plural.go
+++ b/common/naming/plural.go
@@ -63,6 +63,13 @@ func (s PluralString) MarshalText() ([]byte, error) {
 	return []byte(s.text), nil
 }
 
+// UnmarshalText applies plural formatting to the raw text.
+//
+// It must not delegate to UnmarshalJSON: encoding/json uses TextUnmarshaler for
+// map keys and hands it the unquoted value, whereas UnmarshalJSON expects a
+// quoted JSON string. This mirrors MarshalText, which writes the raw text.
 func (s *PluralString) UnmarshalText(text []byte) error {
-	return s.UnmarshalJSON(text)
+	s.text = pluralizer.Plural(string(text))
+
+	return nil
 }

--- a/common/naming/singular.go
+++ b/common/naming/singular.go
@@ -71,8 +71,15 @@ func (s SingularString) MarshalText() ([]byte, error) {
 	return []byte(s.text), nil
 }
 
+// UnmarshalText applies singular formatting to the raw text.
+//
+// It must not delegate to UnmarshalJSON: encoding/json uses TextUnmarshaler for
+// map keys and hands it the unquoted value, whereas UnmarshalJSON expects a
+// quoted JSON string. This mirrors MarshalText, which writes the raw text.
 func (s *SingularString) UnmarshalText(text []byte) error {
-	return s.UnmarshalJSON(text)
+	s.text = pluralizer.Singular(string(text))
+
+	return nil
 }
 
 func PluralityAndCaseIgnoreEqual(a, b string) bool {

--- a/common/paramsbuilder/metadata.go
+++ b/common/paramsbuilder/metadata.go
@@ -47,7 +47,7 @@ func (m *Metadata) WithMetadata(metadata map[string]string, requiredKeys []strin
 }
 
 func (m *Metadata) GetCatalogVars() []catalogreplacer.CustomCatalogVariable {
-	result := make([]catalogreplacer.CustomCatalogVariable, 0)
+	result := make([]catalogreplacer.CustomCatalogVariable, 0, len(m.Map))
 
 	for key, value := range m.Map {
 		result = append(result, catalogreplacer.CustomCatalogVariable{

--- a/common/printable.go
+++ b/common/printable.go
@@ -20,15 +20,26 @@ import (
 
 const truncationLength = 512 * 1024 // 512 KB
 
+// Field names of the structured detail map attached to HTTP log records.
+const (
+	fieldMethod        = "method"
+	fieldURL           = "url"
+	fieldCorrelationID = "correlationId"
+	fieldHeaders       = "headers"
+)
+
+// mimeTypeXML is the canonical XML media type.
+const mimeTypeXML = "application/xml"
+
 func logRequestWithBody(logger *slog.Logger, req *http.Request, method, id, fullURL string, body []byte) {
 	headers := redactSensitiveRequestHeaders(GetRequestHeaders(req))
 
 	logger = logger.With(
 		"details", map[string]any{
-			"method":        method,
-			"url":           fullURL,
-			"correlationId": id,
-			"headers":       headers,
+			fieldMethod:        method,
+			fieldURL:           fullURL,
+			fieldCorrelationID: id,
+			fieldHeaders:       headers,
 		},
 	)
 
@@ -77,11 +88,11 @@ func logResponseWithoutBody(logger *slog.Logger, res *http.Response, method, id,
 
 	logger = logger.With(
 		"details", map[string]any{
-			"method":        method,
-			"url":           fullURL,
-			"correlationId": id,
-			"headers":       headers,
-			"status":        res.StatusCode,
+			fieldMethod:        method,
+			fieldURL:           fullURL,
+			fieldCorrelationID: id,
+			fieldHeaders:       headers,
+			"status":           res.StatusCode,
 		},
 	)
 
@@ -104,11 +115,11 @@ func logResponseWithBody(logger *slog.Logger, res *http.Response, method, id, fu
 
 	logger = logger.With(
 		"details", map[string]any{
-			"method":        method,
-			"url":           fullURL,
-			"correlationId": id,
-			"headers":       headers,
-			"status":        res.StatusCode,
+			fieldMethod:        method,
+			fieldURL:           fullURL,
+			fieldCorrelationID: id,
+			fieldHeaders:       headers,
+			"status":           res.StatusCode,
 		},
 	)
 
@@ -443,7 +454,7 @@ func isPrintableMimeType(mimeType string) bool {
 		strings.HasSuffix(mimeType, "+json") ||
 		strings.HasSuffix(mimeType, "+xml") ||
 		mimeType == "application/json" ||
-		mimeType == "application/xml" ||
+		mimeType == mimeTypeXML ||
 		mimeType == "application/javascript" ||
 		mimeType == "application/x-www-form-urlencoded"
 }

--- a/common/scanning/registry.go
+++ b/common/scanning/registry.go
@@ -340,7 +340,7 @@ func getFromReader[T any](reader Reader) (T, error) {
 func get[T any](val any) (T, error) {
 	var of T
 
-	v, ok := (val).(T)
+	v, ok := val.(T)
 	if !ok {
 		return of, fmt.Errorf("%w. expected %T, got %T", ErrWrongType, of, val)
 	}

--- a/common/substitutions/substitutions.go
+++ b/common/substitutions/substitutions.go
@@ -10,7 +10,7 @@ import (
 // It handles nested structs, pointers, slices, arrays, maps (including pointers-to-maps), and structs inside maps.
 func substituteStruct(input any, substitutions map[string]string) error {
 	val := reflect.ValueOf(input)
-	if val.Kind() != reflect.Ptr || val.IsNil() {
+	if val.Kind() != reflect.Pointer || val.IsNil() {
 		return nil
 	}
 

--- a/common/typemethods.go
+++ b/common/typemethods.go
@@ -14,7 +14,7 @@ package common
 //		FilterBy("age", Gt, 18)
 func (s SearchFilter) FilterBy(fieldName string, operator FilterOperator, value any) SearchFilter {
 	// Copy the slice to avoid aliasing
-	newFilters := make([]FieldFilter, len(s.FieldFilters))
+	newFilters := make([]FieldFilter, len(s.FieldFilters), len(s.FieldFilters)+1)
 	copy(newFilters, s.FieldFilters)
 
 	newFilters = append(newFilters, FieldFilter{

--- a/common/types.go
+++ b/common/types.go
@@ -522,7 +522,7 @@ func (p BatchWriteParam) GetAllOrNone() bool {
 }
 
 func TransformWriteHeaders(headers []WriteHeader, mode HeaderMode) []Header {
-	transformedHeaders := []Header{}
+	transformedHeaders := make([]Header, 0, len(headers))
 	for _, header := range headers {
 		transformedHeaders = append(transformedHeaders, Header{
 			Key:   header.Key,

--- a/common/xml.go
+++ b/common/xml.go
@@ -89,7 +89,7 @@ func parseXMLResponse(res *http.Response, body []byte) (*XMLHTTPResponse, error)
 			return nil, fmt.Errorf("failed to parse content type: %w", err)
 		}
 
-		if mimeType != "application/xml" && mimeType != "text/xml" {
+		if mimeType != mimeTypeXML && mimeType != "text/xml" {
 			return nil, fmt.Errorf("%w: expected content type to be application/xml, got %s", ErrNotXML, mimeType)
 		}
 	}
@@ -116,7 +116,7 @@ func addAcceptXMLHeader(headers []Header) []Header {
 		headers = make([]Header, 0)
 	}
 
-	return append(headers, Header{Key: "Accept", Value: "application/xml"})
+	return append(headers, Header{Key: "Accept", Value: mimeTypeXML})
 }
 
 type XMLSchema interface {

--- a/generic/params.go
+++ b/generic/params.go
@@ -73,9 +73,8 @@ func WithMetadata(metadata map[string]string) Option {
 }
 
 func (p parameters) GetCatalogVars() []catalogreplacer.CatalogVariable {
-	variables := []catalogreplacer.CatalogVariable{
-		&p.Workspace,
-	}
+	variables := make([]catalogreplacer.CatalogVariable, 0, 1+len(p.Metadata.GetCatalogVars()))
+	variables = append(variables, &p.Workspace)
 
 	for _, v := range p.Metadata.GetCatalogVars() {
 		variables = append(variables, v)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amp-labs/connectors
 
-go 1.26.5
+go 1.27.1
 
 require (
 	cloud.google.com/go/bigquery v1.82.0

--- a/internal/datautils/maps.go
+++ b/internal/datautils/maps.go
@@ -64,7 +64,7 @@ func (m Map[K, V]) DeepCopy() (Map[K, V], error) {
 }
 
 func (m Map[K, V]) Keys() []K {
-	keys := make([]K, 0)
+	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}

--- a/internal/staticschema/core.go
+++ b/internal/staticschema/core.go
@@ -127,14 +127,14 @@ func (m FieldMetadataMapV2) convertToCommon() map[string]common.FieldMetadata {
 // The immutable map serves as a unified registry of metadata for the connector.
 // ListObjectMetadata returns a copy that consumers are allowed to modify as needed.
 func (o Object[F, C]) getObjectMetadata() *common.ObjectMetadata {
-	if fieldsMap, isV1 := (any(o.Fields)).(FieldMetadataMapV1); isV1 {
+	if fieldsMap, isV1 := any(o.Fields).(FieldMetadataMapV1); isV1 {
 		return &common.ObjectMetadata{
 			DisplayName: o.DisplayName,
 			FieldsMap:   datautils.FromMap(fieldsMap).ShallowCopy(),
 		}
 	}
 
-	fields, isV2 := (any(o.Fields)).(FieldMetadataMapV2)
+	fields, isV2 := any(o.Fields).(FieldMetadataMapV2)
 	if !isV2 {
 		// Unknown fieldsMap version.
 		return &common.ObjectMetadata{}
@@ -188,20 +188,20 @@ func (m *Metadata[F, C]) Add( // nolint:funlen
 	// - This is a workaround for limitations in Go generics.
 	// - During compilation, only one execution path is valid for each concrete type.
 	//   The other paths are unreachable and conceptually invalid, as they pertain to entirely different types.
-	if presentFields, isV1 := (any(object.Fields)).(FieldMetadataMapV1); isV1 {
+	if presentFields, isV1 := any(object.Fields).(FieldMetadataMapV1); isV1 {
 		fieldsMap := make(FieldMetadataMapV1)
 		maps.Copy(fieldsMap, presentFields)
-		maps.Copy(fieldsMap, (any(fieldMetadataMap)).(FieldMetadataMapV1)) // nolint:forcetypeassert
+		maps.Copy(fieldsMap, any(fieldMetadataMap).(FieldMetadataMapV1)) // nolint:forcetypeassert
 
 		object.Fields = any(fieldsMap).(F) // nolint:forcetypeassert
 
 		return
 	}
 
-	if presentFields, isV2 := (any(object.Fields)).(FieldMetadataMapV2); isV2 {
+	if presentFields, isV2 := any(object.Fields).(FieldMetadataMapV2); isV2 {
 		fieldsMap := make(FieldMetadataMapV2)
 		maps.Copy(fieldsMap, presentFields)
-		maps.Copy(fieldsMap, (any(fieldMetadataMap)).(FieldMetadataMapV2)) // nolint:forcetypeassert
+		maps.Copy(fieldsMap, any(fieldMetadataMap).(FieldMetadataMapV2)) // nolint:forcetypeassert
 
 		object.Fields = any(fieldsMap).(F) // nolint:forcetypeassert
 

--- a/memstore/hashing.go
+++ b/memstore/hashing.go
@@ -142,7 +142,9 @@ func (b *hashBuilder) Int64(v int64) *hashBuilder {
 	b.incrementField()
 
 	bts := make([]byte, int64Size)
-	binary.BigEndian.PutUint64(bts, uint64(v))
+	// G115: int64 and uint64 are the same width, so this is a deliberate
+	// reinterpretation of the bit pattern to get a deterministic encoding.
+	binary.BigEndian.PutUint64(bts, uint64(v)) //nolint:gosec
 
 	b.write(bts)
 

--- a/memstore/schema.go
+++ b/memstore/schema.go
@@ -22,16 +22,14 @@ func injectExtrasIntoSchemaMap(schemaMap map[string]any, structType reflect.Type
 
 	// Iterate over struct fields and extract jsonschema_extras tags
 	//nolint:intrange // NumField() is a method call with potential side effects
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-
+	for field := range structType.Fields() {
 		// Get the JSON name for the field
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {
 			continue
 		}
 		// Extract just the field name (before any options like omitempty)
-		jsonName := strings.Split(jsonTag, ",")[0]
+		jsonName, _, _ := strings.Cut(jsonTag, ",")
 
 		// Get jsonschema_extras tag
 		extrasTag := field.Tag.Get("jsonschema_extras")
@@ -94,16 +92,14 @@ func filterRequiredFields(schemaMap map[string]any, structType reflect.Type) {
 	requiredFields := make(map[string]bool)
 
 	//nolint:intrange // NumField() is a method call with potential side effects
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-
+	for field := range structType.Fields() {
 		// Get the JSON name for the field
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {
 			continue
 		}
 		// Extract just the field name (before any options like omitempty)
-		jsonName := strings.Split(jsonTag, ",")[0]
+		jsonName, _, _ := strings.Cut(jsonTag, ",")
 
 		// Check for "required" in jsonschema tag
 		jsonschemaTag := field.Tag.Get("jsonschema")
@@ -219,14 +215,14 @@ func DeriveSchemasFromStructs(schemas map[string]any) (map[string][]byte, error)
 		}
 
 		// Check for typed nil pointers (e.g., (*MyStruct)(nil))
-		if val.Kind() == reflect.Ptr && val.IsNil() {
+		if val.Kind() == reflect.Pointer && val.IsNil() {
 			return nil, fmt.Errorf("object %s: %w", objectName, ErrNilStruct)
 		}
 
 		typ := val.Type()
 
 		// Dereference pointer if needed
-		if typ.Kind() == reflect.Ptr {
+		if typ.Kind() == reflect.Pointer {
 			typ = typ.Elem()
 		}
 

--- a/providers/acculynx/incremental.go
+++ b/providers/acculynx/incremental.go
@@ -66,6 +66,7 @@ var objectReadSpecs = datautils.NewDefaultMap(map[string]objectReadSpec{
 	"contacts/phone-numbers":    {pagination: paginationNone},
 	"jobs/contacts":             {pagination: paginationNone},
 	"jobs/milestone-history":    {pagination: paginationNone},
+
 	"company-settings/job-file-settings/workflow-milestones": {pagination: paginationNone},
 	"company-settings/location-settings/account-types":       {pagination: paginationNone},
 }, func(string) objectReadSpec {

--- a/providers/atlassian/errors.go
+++ b/providers/atlassian/errors.go
@@ -49,7 +49,7 @@ func (r ResponseMessagesError) CombineErr(base error) error {
 	}
 
 	if len(r.Errors) != 0 {
-		messages := make([]string, 0)
+		messages := make([]string, 0, len(r.Errors))
 		for k, v := range r.Errors {
 			messages = append(messages, fmt.Sprintf("%v:%v", k, v))
 		}

--- a/providers/atlassian/jwt.go
+++ b/providers/atlassian/jwt.go
@@ -130,7 +130,7 @@ func canonicalizeQueryString(query map[string][]string) string {
 		encodedName := encodeRFC3986(paramName)
 
 		// URL-encode parameter values.
-		var encodedValues []string
+		encodedValues := make([]string, 0, len(paramValues))
 		for _, val := range paramValues {
 			encodedValues = append(encodedValues, encodeRFC3986(val))
 		}

--- a/providers/attio/subscriptionEvent.go
+++ b/providers/attio/subscriptionEvent.go
@@ -119,7 +119,7 @@ func (evt SubscriptionEvent) ObjectName() (string, error) {
 		return "", err
 	}
 
-	objectName := strings.Split(name, ".")[0]
+	objectName, _, _ := strings.Cut(name, ".")
 
 	return objectName, nil
 }
@@ -185,7 +185,7 @@ func (evt SubscriptionEvent) RecordId() (string, error) {
 
 	// event_type has the form "{object}.{action}"; the object portion determines
 	// which key inside the "id" object holds the record identifier.
-	eventObject := strings.Split(eventName, ".")[0]
+	eventObject, _, _ := strings.Cut(eventName, ".")
 
 	idKey, ok := recordIDKeyByEventObject[eventObject]
 	if !ok {

--- a/providers/attio/utils.go
+++ b/providers/attio/utils.go
@@ -18,7 +18,8 @@ func getObjectEvents(objectName common.ObjectName) (objectEvents, bool) {
 
 // getAllSupportedEvents returns all provider events that this object supports.
 func (e objectEvents) getAllSupportedEvents() []providerEvent {
-	var events []providerEvent
+	events := make([]providerEvent, 0,
+		len(e.createEvents)+len(e.updateEvents)+len(e.deleteEvents))
 
 	events = append(events, e.createEvents...)
 	events = append(events, e.updateEvents...)

--- a/providers/aws/connector.go
+++ b/providers/aws/connector.go
@@ -56,14 +56,10 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 func constructor(base *components.Connector, expectedMetadataKeys []string) (*Connector, error) {
 	connector := &Connector{
 		Connector: base,
-		RequireModule: common.RequireModule{
-			ExpectedModules: []common.ModuleID{
-				providers.ModuleAWSIdentityCenter,
-			},
+		ExpectedModules: []common.ModuleID{
+			providers.ModuleAWSIdentityCenter,
 		},
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: expectedMetadataKeys,
-		},
+		ExpectedMetadataKeys: expectedMetadataKeys,
 	}
 
 	registry, err := components.NewEndpointRegistry(supportedOperations())

--- a/providers/breezy/connector.go
+++ b/providers/breezy/connector.go
@@ -33,11 +33,9 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"company_id"},
-		},
-		CompanyID: params.Metadata["company_id"],
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"company_id"},
+		CompanyID:            params.Metadata["company_id"],
 	}
 
 	connector.SchemaProvider = schema.NewOpenAPISchemaProvider(

--- a/providers/connectwise/communication-types.go
+++ b/providers/connectwise/communication-types.go
@@ -624,7 +624,8 @@ func allJsonPatchOperations(intent *communicationItemsIntent,
 	output = append(output, opPhone...)
 	output = append(output, opFax...)
 
-	var opRemove []patchOperationPayload
+	opRemove := make([]patchOperationPayload, 0,
+		len(removeEmail)+len(removePhone)+len(removeFax))
 
 	opRemove = append(opRemove, removeEmail...)
 	opRemove = append(opRemove, removePhone...)

--- a/providers/connectwise/connector.go
+++ b/providers/connectwise/connector.go
@@ -54,11 +54,9 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 func constructor(params common.ConnectorParams, base *components.Connector) (*Connector, error) {
 	clientID := params.Metadata["clientId"]
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"clientId"},
-		},
-		clientID: clientID,
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"clientId"},
+		clientID:             clientID,
 	}
 
 	errorHandler := interpreter.ErrorHandler{

--- a/providers/copper/connector.go
+++ b/providers/copper/connector.go
@@ -47,10 +47,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"userEmail"},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"userEmail"},
 	}
 
 	errorHandler := interpreter.ErrorHandler{

--- a/providers/copper/custom.go
+++ b/providers/copper/custom.go
@@ -70,7 +70,7 @@ func (c customFieldResponse) BelongsToObject(objectName string) bool {
 }
 
 func (c customFieldResponse) getValues() []common.FieldValue {
-	fields := make([]common.FieldValue, 0)
+	fields := make([]common.FieldValue, 0, len(c.Options))
 
 	for _, option := range c.Options {
 		fields = append(fields, common.FieldValue{

--- a/providers/dynamicsbusiness/connector.go
+++ b/providers/dynamicsbusiness/connector.go
@@ -54,11 +54,9 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{metadataKeyCompanyID, metadataKeyEnvironmentName},
-		},
-		incrementalRegistry: datautils.NewCache[string, bool](),
+		Connector:            base,
+		ExpectedMetadataKeys: []string{metadataKeyCompanyID, metadataKeyEnvironmentName},
+		incrementalRegistry:  datautils.NewCache[string, bool](),
 	}
 
 	connector.SchemaProvider = schema.NewObjectSchemaProvider(

--- a/providers/g2/connector.go
+++ b/providers/g2/connector.go
@@ -56,10 +56,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"subjectProductId"},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"subjectProductId"},
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/g2/utils.go
+++ b/providers/g2/utils.go
@@ -227,7 +227,7 @@ func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, err
 		dimensions.Add(params.Fields.List())
 
 		// If a user is reading buyer_intent we need the time field for incremental read sync.
-		if !dimensions.Has("time") && (buyerIntents.Has(params.ObjectName)) { //nolint:lll
+		if !dimensions.Has("time") && buyerIntents.Has(params.ObjectName) { //nolint:lll
 			dimensions.Add([]string{"time"})
 		}
 

--- a/providers/highlevelstandard/handlers.go
+++ b/providers/highlevelstandard/handlers.go
@@ -45,7 +45,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 	//
 	// For multi-segment paths (e.g., "calendars/groups"), the URL does not require a trailing slash.
 	// Example: https://highlevel.stoplight.io/docs/integrations/89e47b6c05e67-get-groups
-	if !(strings.Contains(objectName, "/")) {
+	if !strings.Contains(objectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err
@@ -159,7 +159,7 @@ func (c *Connector) buildReadRequest( // nolint:cyclop
 	//
 	// For multi-segment paths (e.g., "calendars/groups"), the URL does not require a trailing slash.
 	// Example: https://highlevel.stoplight.io/docs/integrations/89e47b6c05e67-get-groups
-	if !(strings.Contains(params.ObjectName, "/")) {
+	if !strings.Contains(params.ObjectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err
@@ -229,7 +229,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	if !(strings.Contains(params.ObjectName, "/")) {
+	if !strings.Contains(params.ObjectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err

--- a/providers/highlevelwhitelabel/handlers.go
+++ b/providers/highlevelwhitelabel/handlers.go
@@ -45,7 +45,7 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 	//
 	// For multi-segment paths (e.g., "calendars/groups"), the URL does not require a trailing slash.
 	// Example: https://highlevel.stoplight.io/docs/integrations/89e47b6c05e67-get-groups
-	if !(strings.Contains(objectName, "/")) {
+	if !strings.Contains(objectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err
@@ -159,7 +159,7 @@ func (c *Connector) buildReadRequest( // nolint:cyclop
 	//
 	// For multi-segment paths (e.g., "calendars/groups"), the URL does not require a trailing slash.
 	// Example: https://highlevel.stoplight.io/docs/integrations/89e47b6c05e67-get-groups
-	if !(strings.Contains(params.ObjectName, "/")) {
+	if !strings.Contains(params.ObjectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err
@@ -229,7 +229,7 @@ func (c *Connector) buildWriteRequest(ctx context.Context, params common.WritePa
 		return nil, err
 	}
 
-	if !(strings.Contains(params.ObjectName, "/")) {
+	if !strings.Contains(params.ObjectName, "/") {
 		urlRaw, err := url.ToURL()
 		if err != nil {
 			return nil, err

--- a/providers/hubspot/internal/custom/metadata.go
+++ b/providers/hubspot/internal/custom/metadata.go
@@ -118,8 +118,7 @@ func (a *Adapter) fetchGroupName(ctx context.Context, objectName string) (*strin
 	if err != nil {
 		// Check that record was not found.
 		// It is not considered an error but a valid exist path.
-		var httpError *common.HTTPError
-		if errors.As(err, &httpError) {
+		if httpError, ok := errors.AsType[*common.HTTPError](err); ok {
 			if httpError.Status == http.StatusNotFound {
 				return nil, nil // nolint:nilnil
 			}

--- a/providers/hubspot/metadata.go
+++ b/providers/hubspot/metadata.go
@@ -175,12 +175,10 @@ func (c *Connector) getObjectMetadataFromCRMSearch(
 	ctx context.Context, objectName string,
 ) (*common.ObjectMetadata, error) {
 	readResult, err := c.searchCRM(ctx, searchCRMParams{
-		SearchParams: SearchParams{
-			ObjectName: objectName,
-			Fields:     connectors.Fields(""), // passed to satisfy validation
-			NextPage:   "",
-		},
-		PageSize: 1,
+		ObjectName: objectName,
+		Fields:     connectors.Fields(""), // passed to satisfy validation
+		NextPage:   "",
+		PageSize:   1,
 	})
 	if err != nil {
 		// Ignore an error and fallback to static schema.

--- a/providers/hubspot/read.go
+++ b/providers/hubspot/read.go
@@ -41,11 +41,9 @@ func (c *Connector) Read(ctx context.Context, params common.ReadParams) (*common
 		// Object is part of CRM namespace but outside ObjectAPI.
 		// For instance object "lists" is returned only via CRM Search endpoint.
 		return c.searchCRM(ctx, searchCRMParams{
-			SearchParams: SearchParams{
-				ObjectName: params.ObjectName,
-				NextPage:   params.NextPage,
-				Fields:     params.Fields,
-			},
+			ObjectName: params.ObjectName,
+			NextPage:   params.NextPage,
+			Fields:     params.Fields,
 		})
 	case core.MarketingObjects.Has(params.ObjectName):
 		// Object is part of Hubspot Marketing API.

--- a/providers/jobber/subscribe.go
+++ b/providers/jobber/subscribe.go
@@ -372,16 +372,18 @@ func (c *Connector) rollbackWebhookEndpoints(
 	}
 
 	if _, err := c.deleteWebhookEndpoints(ctx, ids); err != nil {
-		return &common.SubscriptionResult{
-				Status:       common.SubscriptionStatusFailedToRollback,
-				ObjectEvents: buildObjectEvents(endpoints),
-				Result: &SubscriptionResult{
-					Endpoints: endpoints,
-				},
-			}, errors.Join(
-				cause,
-				fmt.Errorf("failed to rollback webhook endpoints: %w", err),
-			)
+		result := &common.SubscriptionResult{
+			Status:       common.SubscriptionStatusFailedToRollback,
+			ObjectEvents: buildObjectEvents(endpoints),
+			Result: &SubscriptionResult{
+				Endpoints: endpoints,
+			},
+		}
+
+		return result, errors.Join(
+			cause,
+			fmt.Errorf("failed to rollback webhook endpoints: %w", err),
+		)
 	}
 
 	return &common.SubscriptionResult{Status: common.SubscriptionStatusFailed}, cause

--- a/providers/linkedin/internal/ads/adapter.go
+++ b/providers/linkedin/internal/ads/adapter.go
@@ -52,10 +52,8 @@ func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
 // nolint:funlen
 func constructor(base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"adAccountId"},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"adAccountId"},
 	}
 
 	// LinkedIn's OpenAPI files only cover the adAnalytics object.

--- a/providers/loxo/connector.go
+++ b/providers/loxo/connector.go
@@ -47,10 +47,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"agencySlug"},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"agencySlug"},
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/meta/internal/whatsapp/adapter.go
+++ b/providers/meta/internal/whatsapp/adapter.go
@@ -37,11 +37,9 @@ func NewAdapter(params common.ConnectorParams) (*Adapter, error) {
 func constructor(base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
 		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{
-				metadataKeyWhatsAppAccountID,
-				metadataKeyPhoneNumberID,
-			},
+		ExpectedMetadataKeys: []string{
+			metadataKeyWhatsAppAccountID,
+			metadataKeyPhoneNumberID,
 		},
 	}
 

--- a/providers/microsoft/internal/batch/response.go
+++ b/providers/microsoft/internal/batch/response.go
@@ -118,7 +118,7 @@ type response[B any] struct {
 }
 
 func (b response[B]) getHeaders() common.Headers {
-	headers := make(common.Headers, 0)
+	headers := make(common.Headers, 0, len(b.Headers))
 	for key, value := range b.Headers {
 		headers = append(headers, common.Header{
 			Key:   key,

--- a/providers/netsuite/internal/suiteql/metadata.go
+++ b/providers/netsuite/internal/suiteql/metadata.go
@@ -19,7 +19,9 @@ func (a *Adapter) buildObjectMetadataRequest(ctx context.Context, objectName str
 	}
 
 	body := suiteQLQueryBody{
-		Query: "SELECT * FROM " + objectName,
+		// unqueryvet: metadata discovery fetches one row (limit 1) to learn the
+		// record type's columns, so they cannot be listed explicitly.
+		Query: "SELECT * FROM " + objectName, //nolint:unqueryvet
 	}
 
 	url.WithQueryParam("limit", "1")

--- a/providers/netsuite/internal/suiteql/read.go
+++ b/providers/netsuite/internal/suiteql/read.go
@@ -77,7 +77,9 @@ func (a *Adapter) parseReadResponse(
 
 func makeSuiteQLBody(params common.ReadParams) suiteQLQueryBody {
 	body := suiteQLQueryBody{
-		Query: "SELECT * FROM " + params.ObjectName,
+		// unqueryvet: ObjectName is an arbitrary NetSuite record type, so the
+		// connector cannot know its columns ahead of time.
+		Query: "SELECT * FROM " + params.ObjectName, //nolint:unqueryvet
 	}
 
 	dateColumn := "lastModifiedDate"

--- a/providers/pipedrive/internal/crm/metadata.go
+++ b/providers/pipedrive/internal/crm/metadata.go
@@ -126,7 +126,7 @@ func (a *Adapter) parseMetadata( // nolint: gocognit,gocyclo,cyclop,funlen
 		mdtFlds := &common.FieldMetadata{
 			DisplayName:  fldRcd.Name,
 			IsCustom:     &fldRcd.IsCustom,
-			IsRequired:   &(req),
+			IsRequired:   &req,
 			ProviderType: fldRcd.FieldType,
 			ValueType:    nativeValueType(fldRcd.FieldType),
 		}

--- a/providers/procore/connector.go
+++ b/providers/procore/connector.go
@@ -54,10 +54,8 @@ func NewSandboxConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{metadataKeyCompany},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{metadataKeyCompany},
 	}
 
 	// Set the metadata provider for the connector

--- a/providers/quickbooks/handlers.go
+++ b/providers/quickbooks/handlers.go
@@ -20,7 +20,10 @@ func (c *Connector) buildSingleObjectMetadataRequest(ctx context.Context, object
 		return nil, err
 	}
 
-	Query := "SELECT * FROM " + naming.CapitalizeFirstLetter(objectName) + " STARTPOSITION 0 MAXRESULTS 1"
+	// unqueryvet: this is metadata discovery - it fetches a single row precisely
+	// to learn which columns the object has, so the column list cannot be named.
+	Query := "SELECT * FROM " + naming.CapitalizeFirstLetter(objectName) + //nolint:unqueryvet
+		" STARTPOSITION 0 MAXRESULTS 1"
 
 	url.WithQueryParam("query", Query)
 

--- a/providers/quickbooks/utils.go
+++ b/providers/quickbooks/utils.go
@@ -32,7 +32,9 @@ func buildQuery(params common.ReadParams) string {
 		untilQuery      string
 	)
 
-	query := "SELECT * FROM " + naming.CapitalizeFirstLetter(params.ObjectName)
+	// unqueryvet: ObjectName is an arbitrary QuickBooks entity, so the connector
+	// cannot name its columns ahead of time.
+	query := "SELECT * FROM " + naming.CapitalizeFirstLetter(params.ObjectName) //nolint:unqueryvet
 
 	if params.NextPage != "" {
 		paginationQuery = " STARTPOSITION " + params.NextPage.String() + " MAXRESULTS " + pageSize

--- a/providers/revenuecat/connector.go
+++ b/providers/revenuecat/connector.go
@@ -42,10 +42,8 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 
 func constructor(base *components.Connector) (*Connector, error) {
 	connector := &Connector{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{"project_id"},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{"project_id"},
 	}
 
 	connector.SchemaProvider = schema.NewCompositeSchemaProvider(

--- a/providers/ringcentral/utils.go
+++ b/providers/ringcentral/utils.go
@@ -40,7 +40,7 @@ func GetFieldByJSONTag(resp *Response, jsonTag string) ([]map[string]any, error)
 				return nil, fmt.Errorf("field with tag '%s' is not a slice", jsonTag) //nolint: err113
 			}
 
-			result, ok := fieldValue.Interface().([]map[string]any)
+			result, ok := reflect.TypeAssert[[]map[string]any](fieldValue)
 			if !ok {
 				return nil, fmt.Errorf("field with tag '%s' is not of type []map[string]any", jsonTag) //nolint: err113
 			}

--- a/providers/salesforce/bulk-delete.go
+++ b/providers/salesforce/bulk-delete.go
@@ -14,7 +14,7 @@ import (
 // * GetJobResults
 // * GetSuccessfulJobResults.
 //
-//nolint:stylecheck
+//nolint:staticcheck
 func (c *Connector) BulkDelete(ctx context.Context, params BulkOperationParams) (*BulkOperationResult, error) {
 	if len(params.ObjectName) == 0 {
 		return nil, common.ErrMissingObjects

--- a/providers/salesforce/internal/pardot/adapter.go
+++ b/providers/salesforce/internal/pardot/adapter.go
@@ -47,10 +47,8 @@ func NewAdapter(params *common.ConnectorParams, provider providers.Provider) (*A
 
 func constructor(base *components.Connector) (*Adapter, error) {
 	adapter := &Adapter{
-		Connector: base,
-		RequireMetadata: common.RequireMetadata{
-			ExpectedMetadataKeys: []string{MetadataKeyBusinessUnitID},
-		},
+		Connector:            base,
+		ExpectedMetadataKeys: []string{MetadataKeyBusinessUnitID},
 	}
 
 	errorHandler := errorHandlerFunc

--- a/providers/salesforce/jwt/jwt.go
+++ b/providers/salesforce/jwt/jwt.go
@@ -345,6 +345,8 @@ func newUnauthorizedHandler(rts *retryingTokenSource) func(
 		retryReq := req.Clone(req.Context())
 		retryReq.Header.Set("Authorization", tok.TokenType+" "+tok.AccessToken)
 
-		return http.DefaultClient.Do(retryReq)
+		// G704: retryReq is a clone of a request this connector already sent;
+		// only the Authorization header changes, so the destination is unchanged.
+		return http.DefaultClient.Do(retryReq) //nolint:gosec
 	}
 }

--- a/providers/salesforce/record.go
+++ b/providers/salesforce/record.go
@@ -19,11 +19,9 @@ func (c *Connector) GetRecordsByIds( // nolint:revive
 ) ([]common.ReadResultRow, error) {
 	// Sanitize method arguments.
 	config := recordsByIDsParams{
-		ReadParams: common.ReadParams{
-			ObjectName:        objectName,
-			Fields:            datautils.NewSetFromList(fields),
-			AssociatedObjects: associations,
-		},
+		ObjectName:        objectName,
+		Fields:            datautils.NewSetFromList(fields),
+		AssociatedObjects: associations,
 		RecordIdentifiers: datautils.NewSetFromList(ids),
 	}
 

--- a/providers/salesloft/subscribe.go
+++ b/providers/salesloft/subscribe.go
@@ -476,7 +476,8 @@ func (m eventMapping) toProviderEvents(commonEvent common.SubscriptionEventType)
 
 // getAllSupportedEvents returns all provider events that this mapping supports.
 func (m eventMapping) getAllSupportedEvents() []moduleEvent {
-	var events []moduleEvent
+	events := make([]moduleEvent, 0,
+		len(m.CreateEvents)+len(m.UpdateEvents)+len(m.DeleteEvents))
 
 	events = append(events, m.CreateEvents...)
 	events = append(events, m.UpdateEvents...)

--- a/providers/sellsy/custom.go
+++ b/providers/sellsy/custom.go
@@ -146,7 +146,7 @@ func (d customFieldDefinition) getValueType() common.ValueType {
 }
 
 func (d customFieldDefinition) getValues() []common.FieldValue {
-	result := make([]common.FieldValue, 0)
+	result := make([]common.FieldValue, 0, len(d.Parameters.Items))
 
 	for _, item := range d.Parameters.Items {
 		result = append(result, common.FieldValue{

--- a/providers/snowflake/postAuth.go
+++ b/providers/snowflake/postAuth.go
@@ -196,8 +196,10 @@ func (c *Connector) createStream(ctx context.Context, streamName, dynamicTableNa
 // validateQuery validates a SQL query by running EXPLAIN.
 // This checks syntax and permissions without executing the query.
 func (c *Connector) validateQuery(ctx context.Context, query string) error {
-	// query is the user's SQL definition - intentional raw SQL for Dynamic Table feature
-	explainQuery := "EXPLAIN " + query
+	// query is the user's SQL definition - intentional raw SQL for Dynamic Table feature.
+	// G202: a query body cannot be bound as a parameter, so prefixing EXPLAIN is
+	// the only way to validate it. Same rationale as the globally excluded G201.
+	explainQuery := "EXPLAIN " + query //nolint:gosec
 
 	rows, err := c.handle.db.QueryContext(ctx, explainQuery)
 	if err != nil {

--- a/providers/square/objects.go
+++ b/providers/square/objects.go
@@ -4,8 +4,10 @@ const apiVersion = "v2"
 
 // objectCatalogItems reads the catalog through the SearchCatalogItems endpoint,
 // which returns item objects only, unlike the mixed-type "catalog" list.
-const objectCatalogItems = "catalogItems"
-const objectTeamMembers = "teamMembers"
+const (
+	objectCatalogItems = "catalogItems"
+	objectTeamMembers  = "teamMembers"
+)
 
 // objectConfig is the single source of truth for a Square object: how to list
 // its records, and (when supported) how to create/update them. Write fields

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -763,7 +763,9 @@ func customRefreshHandler(
 				return nil, err
 			}
 
-			resp, err := rawClient.Do(replay) //nolint:bodyclose // returned to caller, or closed below before retrying
+			// G704: replay re-renders a request this connector already sent, against
+			// the same URL; refreshing credentials does not change the destination.
+			resp, err := rawClient.Do(replay) //nolint:bodyclose,gosec // returned to caller, or closed below before retrying
 			if err != nil {
 				return nil, err
 			}

--- a/providers/zendesksupport/customFields.go
+++ b/providers/zendesksupport/customFields.go
@@ -98,7 +98,8 @@ func (f ticketField) GetValueType() common.ValueType {
 }
 
 func (f ticketField) getValues() []common.FieldValue {
-	result := make([]common.FieldValue, 0)
+	result := make([]common.FieldValue, 0,
+		len(f.SystemFieldOptions)+len(f.CustomFieldOptions)+len(f.CustomStatuses))
 
 	for _, option := range f.SystemFieldOptions {
 		result = append(result, common.FieldValue{

--- a/providers/zoho/subscribe.go
+++ b/providers/zoho/subscribe.go
@@ -334,7 +334,7 @@ func (c *Connector) getModuleMetadata(
 	ctx context.Context,
 	params common.SubscribeParams,
 ) (map[string]map[string]any, error) {
-	objectNames := make([]string, 0)
+	objectNames := make([]string, 0, len(params.SubscriptionEvents))
 	for obj := range params.SubscriptionEvents {
 		objectNames = append(objectNames, string(obj))
 	}

--- a/scripts/schemadocs/copper/main.go
+++ b/scripts/schemadocs/copper/main.go
@@ -53,7 +53,7 @@ type objectDefinition struct {
 }
 
 func (d objectDefinition) GetFields() []staticschema.FieldMetadataMapV2 {
-	fields := make([]staticschema.FieldMetadataMapV2, 0)
+	fields := make([]staticschema.FieldMetadataMapV2, 0, len(d.Sample))
 
 	for fieldName, value := range d.Sample {
 		primitiveType := getPrimitiveType(value)

--- a/scripts/utils/proxyserv/custom.go
+++ b/scripts/utils/proxyserv/custom.go
@@ -115,7 +115,7 @@ func forEachField(callback func(name string, f credscanning.Field)) {
 	for i := range v.NumField() {
 		name := t.Field(i).Name
 
-		f, ok := v.Field(i).Interface().(credscanning.Field)
+		f, ok := reflect.TypeAssert[credscanning.Field](v.Field(i))
 		if !ok {
 			// If the field is not of type credscanning.Field, skip it
 			continue


### PR DESCRIPTION
Upgrades the toolchain to Go 1.27 and brings the linter forward to match. Companion to amp-labs/amp-common#263.

| | Before | After |
|---|---|---|
| `go.mod` | 1.26.5 | **1.27.1** |
| CI Go — `linter.yml` | 1.26.1 | **1.27.1** |
| CI Go — `build.yml` | 1.26.5 | **1.27.1** |
| golangci-lint (3 pins) | v2.7.1 | **v2.13.2** |

## The linter bump is mandatory, not cosmetic

golangci-lint v2.7.1 **cannot analyze Go 1.27 code at all**:

```
cannot decode "internal/goarch", export data version 4 is
greater than maximum supported version 2
```

Go 1.27 advanced the export-data format past what v2.7.1's bundled `x/tools` can read, so every package fails to typecheck. The version is pinned in **three** places that must agree — `Makefile`, `.custom-gcl.yml`, and `.github/workflows/linter.yml` — and all three are updated. The `nogoroutine` and `modulelinter` plugins recompile against v2.13.2 with no dependency changes.

## Verification

- `go build ./...`, `go vet ./...` — clean
- **`make lint` — exit 0, and idempotent** (run twice, both pass)
- `go test ./...` — **163 packages pass, 0 failures**

## 🐛 A real bug this surfaced

`TestSingularMarshal` in `common/naming` passed on Go 1.26 and failed on 1.27. This is a genuine defect, not a lint nit:

`SingularString` and `PluralString` are used as **map keys**, and `encoding/json` uses `TextUnmarshaler` for map keys — handing it the *unquoted* key. But `UnmarshalText` delegated to `UnmarshalJSON`, which calls `json.Unmarshal` and expects a *quoted* JSON string. So decoding `{"data":{"potatoes":...}}` failed with `invalid character 'p' looking for beginning of value`. It was also asymmetric with `MarshalText`, which correctly writes the raw text.

Both types now format the raw text directly. **Verified under Go 1.26 as well**, so this is not a 1.27-only patch.

## `make lint` could not converge

gofumpt and gofmt disagree about alignment groups in a map literal containing one outlier-length key: one reformats the file, the other reverts it, so the verification run always reported it as unformatted — an unwinnable loop.

I first assumed the fix was removing redundant formatters from `.golangci.yml`. **I tested that, it did not work, and I reverted that config churn** rather than leave an unjustified change. The real fix is at the source, and both files read better for it:

- `providers/acculynx/incremental.go` — a blank line separating the long `company-settings/...` keys into their own alignment group
- `providers/jobber/subscribe.go` — hoisting a multi-line composite literal out of a multi-value `return`

## Config changes

**Renames.** Version bumps rename linters, which silently breaks `disable:` entries — `exhaustruct` → `exhaustruct_v5` (2850 issues reappeared) and `gomodguard` → `gomodguard_v2`. Both disabled under their new names; `gomodguard_v2` remains enabled via `default: all`, so no coverage is lost.

**Two scoped exclusions**, each documented inline:

| Rule | Scope | Why |
|---|---|---|
| `goconst` | `providers/`, `scripts/` | Each file is an independent declarative description of one SaaS API. Two providers sharing a literal (a header name, a content type) is a coincidence, not a shared concept — hoisting constants would couple unrelated provider definitions. 828 of 891 findings. |
| `gosec` G101 | `providers/` | Declares the *names* of auth headers and fields, not secrets. All 134 findings. G101 stays active everywhere else, where a real hardcoded credential could appear. |

## Everything else is fixed, not suppressed

16 `prealloc`, 7 `goconst` in `common/` extracted as real constants, and a stale `//nolint:stylecheck` (stylecheck was merged into staticcheck in v2, so the directive had become a no-op that the runner warns about).

## Eight justified nolints

Each carries a written reason. The four gosec findings were investigated individually; none is a real vulnerability:

| Site | Rule | Why |
|---|---|---|
| `providers/utils.go`, `salesforce/jwt/jwt.go` | G704 SSRF | Replays a request this connector already sent, at the same URL; refreshing credentials does not change the destination |
| `snowflake/postAuth.go` | G202 | A query body cannot be bound as a parameter, so prefixing `EXPLAIN` is the only way to validate a user-supplied Dynamic Table definition. Same rationale as the already-excluded G201 |
| `memstore/hashing.go` | G115 | `int64`→`uint64` is a same-width reinterpretation for a deterministic encoding |
| netsuite ×2, quickbooks ×2 | unqueryvet | `SELECT *` during metadata discovery — the column set is precisely what is being discovered, so it cannot be named |

🤖 Generated with [Claude Code](https://claude.com/claude-code)