### PR TITLE
[CON-3479] feat(reply): add reply-read

### DIFF
--- a/providers/reply/connector.go
+++ b/providers/reply/connector.go
@@ -2,7 +2,10 @@ package reply
 
 import (
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/interpreter"
 	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/internal/components/operations"
+	"github.com/amp-labs/connectors/internal/components/reader"
 	"github.com/amp-labs/connectors/providers"
 )
 
@@ -13,6 +16,8 @@ const apiVersion = "v3"
 type Connector struct {
 	*components.Connector
 	common.RequireAuthenticatedClient
+
+	components.Reader
 }
 
 func NewConnector(params common.ConnectorParams) (*Connector, error) {
@@ -20,7 +25,29 @@ func NewConnector(params common.ConnectorParams) (*Connector, error) {
 }
 
 func constructor(base *components.Connector) (*Connector, error) {
-	return &Connector{
+	connector := &Connector{
 		Connector: base,
-	}, nil
+	}
+
+	registry, err := components.NewEndpointRegistry(supportedOperations())
+	if err != nil {
+		return nil, err
+	}
+
+	errorHandler := interpreter.ErrorHandler{
+		JSON: interpreter.NewFaultyResponder(errorFormats, nil),
+	}.Handle
+
+	connector.Reader = reader.NewHTTPReader(
+		connector.HTTPClient().Client,
+		registry,
+		connector.ProviderContext.Module(),
+		operations.ReadHandlers{
+			BuildRequest:  connector.buildReadRequest,
+			ParseResponse: connector.parseReadResponse,
+			ErrorHandler:  errorHandler,
+		},
+	)
+
+	return connector, nil
 }

--- a/providers/reply/errors.go
+++ b/providers/reply/errors.go
@@ -1,0 +1,44 @@
+package reply
+
+import (
+	"fmt"
+
+	"github.com/amp-labs/connectors/common/interpreter"
+)
+
+var errorFormats = interpreter.NewFormatSwitch( // nolint:gochecknoglobals
+	[]interpreter.FormatTemplate{
+		{
+			MustKeys: nil,
+			Template: func() interpreter.ErrorDescriptor { return &ResponseError{} },
+		},
+	}...,
+)
+
+// ResponseError covers both problem+json shapes Reply returns:
+// a plain problem ({"title","status","detail"}) and a validation problem
+// carrying an errors array ({"errors":[{"pointer","detail"}],...}).
+// https://docs.reply.io/api-reference/schemas/problem-details
+type ResponseError struct {
+	Title  string        `json:"title"`
+	Status int           `json:"status"`
+	Detail string        `json:"detail"`
+	Errors []ErrorDetail `json:"errors"`
+}
+
+type ErrorDetail struct {
+	Pointer string `json:"pointer"`
+	Detail  string `json:"detail"`
+}
+
+func (e ResponseError) CombineErr(base error) error {
+	if len(e.Errors) != 0 {
+		return fmt.Errorf("%w: %v: %v %v", base, e.Title, e.Errors[0].Pointer, e.Errors[0].Detail)
+	}
+
+	if e.Title == "" && e.Detail == "" {
+		return base
+	}
+
+	return fmt.Errorf("%w: %v: %v", base, e.Title, e.Detail)
+}

--- a/providers/reply/read.go
+++ b/providers/reply/read.go
@@ -1,0 +1,203 @@
+package reply
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/readhelper"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+	"github.com/amp-labs/connectors/internal/datautils"
+	"github.com/amp-labs/connectors/internal/jsonquery"
+	"github.com/amp-labs/connectors/providers/reply/metadata"
+	"github.com/spyzhov/ajson"
+)
+
+const (
+	// Reply accepts up to 1000 records per page (default 25).
+	// https://docs.reply.io/api-reference/sequences/list-all-sequences
+	defaultPageSize = 100
+
+	objectSequences = "sequences"
+)
+
+// Objects whose list endpoint wraps records in {"items": [...], "hasMore": bool}
+// paginate with top/skip. The remaining objects return a root-level array in a
+// single response, which the empty response key in the schema registry conveys.
+func isPaginated(objectName string) bool {
+	return metadata.Schemas.LookupArrayFieldName(common.ModuleRoot, objectName) != ""
+}
+
+func (c *Connector) buildReadRequest(ctx context.Context, params common.ReadParams) (*http.Request, error) {
+	url, err := c.buildReadURL(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+}
+
+func (c *Connector) buildReadURL(params common.ReadParams) (*urlbuilder.URL, error) {
+	if params.NextPage != "" {
+		return urlbuilder.New(params.NextPage.String())
+	}
+
+	path, err := metadata.Schemas.LookupURLPath(common.ModuleRoot, params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	// path already carries the /v3 module prefix from the schema registry.
+	url, err := urlbuilder.New(c.ProviderInfo().BaseURL, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if isPaginated(params.ObjectName) {
+		url.WithQueryParam("top", strconv.Itoa(defaultPageSize))
+	}
+
+	// Sequences is the only object with a provider-side time filter, and it
+	// scopes by creation time; Until has no provider-side parameter, so the
+	// full window is enforced connector-side on the created field during
+	// parsing. Contacts declare createdAt/lastModifiedAt in their schema, but
+	// the live API always returns null for both and the filter endpoint
+	// silently ignores time rules, so no other object can be read
+	// incrementally (verified against the live API).
+	// https://docs.reply.io/api-reference/sequences/list-all-sequences
+	if params.ObjectName == objectSequences && !params.Since.IsZero() {
+		url.WithQueryParam("createdAfter", datautils.Time.FormatRFC3339inUTC(params.Since))
+	}
+
+	return url, nil
+}
+
+func (c *Connector) parseReadResponse(
+	ctx context.Context,
+	params common.ReadParams,
+	request *http.Request,
+	response *common.JSONHTTPResponse,
+) (*common.ReadResult, error) {
+	transform, err := c.makeRecordTransformer(ctx, params.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.ParseResultFiltered(
+		params,
+		response,
+		makeGetRecords(params.ObjectName),
+		makeFilterFunc(params, request),
+		readhelper.MakeMarshaledDataFuncWithId(transform, readhelper.NewIdField("id")),
+		params.Fields,
+	)
+}
+
+// makeFilterFunc applies the Since/Until window connector-side for sequences —
+// the one object whose records carry a populated timestamp (created). Reply
+// has no provider-side Until parameter, and its documentation states no sort
+// order, so records are treated as unordered. Every other object has no
+// usable timestamp and passes through unfiltered.
+func makeFilterFunc(params common.ReadParams, request *http.Request) common.RecordsFilterFunc {
+	if params.ObjectName != objectSequences {
+		return readhelper.MakeIdentityFilterFunc(makeNextRecordsURL(request))
+	}
+
+	return readhelper.MakeTimeFilterFunc(
+		readhelper.Unordered,
+		readhelper.NewTimeBoundary(),
+		"created", time.RFC3339,
+		makeNextRecordsURL(request))
+}
+
+// makeGetRecords locates the records array: under the schema's response key
+// for enveloped objects, or the response root for bare-array objects (empty
+// response key).
+func makeGetRecords(objectName string) common.NodeRecordsFunc {
+	return func(node *ajson.Node) ([]*ajson.Node, error) {
+		responseKey := metadata.Schemas.LookupArrayFieldName(common.ModuleRoot, objectName)
+
+		return jsonquery.New(node).ArrayOptional(responseKey)
+	}
+}
+
+// makeNextRecordsURL advances the skip offset while the response reports
+// hasMore. Root-level array responses carry no hasMore, so they finish after
+// a single page.
+func makeNextRecordsURL(request *http.Request) common.NextPageFunc {
+	return func(node *ajson.Node) (string, error) {
+		hasMore, err := jsonquery.New(node).BoolWithDefault("hasMore", false)
+		if err != nil || !hasMore {
+			return "", err
+		}
+
+		url, err := urlbuilder.New(request.URL.String())
+		if err != nil {
+			return "", err
+		}
+
+		skip := 0
+
+		if skipStr, ok := url.GetFirstQueryParam("skip"); ok {
+			skip, err = strconv.Atoi(skipStr)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		url.WithQueryParam("skip", strconv.Itoa(skip+defaultPageSize))
+
+		return url.String(), nil
+	}
+}
+
+// makeRecordTransformer resolves contact custom fields to human-readable
+// names: the record's customFields entries carry the numeric definition id as
+// their key, which is matched against the definition titles fetched once per
+// page. Raw is left untouched; the resolved fields are added alongside.
+func (c *Connector) makeRecordTransformer(
+	ctx context.Context, objectName string,
+) (common.RecordTransformer, error) {
+	if objectName != objectCustomFieldsOwner {
+		return nil, nil // nolint:nilnil
+	}
+
+	definitions, err := c.fetchCustomFieldDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	titleByID := make(map[string]string, len(definitions))
+	for _, definition := range definitions {
+		titleByID[strconv.Itoa(definition.ID)] = definition.Title
+	}
+
+	return func(node *ajson.Node) (map[string]any, error) {
+		record, err := jsonquery.Convertor.ObjectToMap(node)
+		if err != nil {
+			return nil, err
+		}
+
+		fields, ok := record["customFields"].([]any)
+		if !ok {
+			return record, nil
+		}
+
+		for _, field := range fields {
+			entry, ok := field.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			key, _ := entry["key"].(string)
+
+			if title, found := titleByID[key]; found {
+				record[title] = entry["value"]
+			}
+		}
+
+		return record, nil
+	}, nil
+}

--- a/providers/reply/read_test.go
+++ b/providers/reply/read_test.go
@@ -1,0 +1,246 @@
+package reply
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+	"github.com/amp-labs/connectors/test/utils/testconn"
+	"github.com/amp-labs/connectors/test/utils/testutils"
+)
+
+func TestRead(t *testing.T) { //nolint:funlen,gocognit,cyclop,maintidx
+	t.Parallel()
+
+	responseContactsFirstPage := testutils.DataFromFile(t, "read/contacts-first-page.json")
+	responseContactsLastPage := testutils.DataFromFile(t, "read/contacts.json")
+	responseCustomFields := testutils.DataFromFile(t, "read/custom-fields.json")
+	responseSchedules := testutils.DataFromFile(t, "read/schedules.json")
+	responseSequences := testutils.DataFromFile(t, "read/sequences.json")
+	errorValidation := testutils.DataFromFile(t, "read/err-validation.json")
+	errorUnauthorized := testutils.DataFromFile(t, "read/err-unauthorized.json")
+
+	tests := []testconn.TestCaseRead{
+		{
+			Name:         "Read object must be included",
+			Input:        common.ReadParams{},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingObjects},
+		},
+		{
+			Name:         "At least one field is requested",
+			Input:        common.ReadParams{ObjectName: "contacts", Fields: nil},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrMissingFields},
+		},
+		{
+			Name:         "Unknown object is rejected by the registry",
+			Input:        common.ReadParams{ObjectName: "butterflies", Fields: connectors.Fields("id")},
+			Server:       mockserver.Dummy(),
+			ExpectedErrs: []error{common.ErrOperationNotSupportedForObject},
+		},
+		{
+			Name: "Contacts first page paginates by skip and resolves custom field titles",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("email"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.MethodGET(),
+						mockcond.Path("/v3/contacts"),
+						mockcond.QueryParam("top", "100"),
+					},
+					Then: mockserver.Response(http.StatusOK, responseContactsFirstPage),
+				}, {
+					If:   mockcond.Path("/v3/custom-fields"),
+					Then: mockserver.Response(http.StatusOK, responseCustomFields),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Id: "761575310",
+					Fields: map[string]any{
+						"email": "john.roe@example.com",
+					},
+					Raw: map[string]any{
+						"firstName": "John",
+						"lastName":  "Roe",
+					},
+				}},
+				NextPage: testconn.URLTestServer + "/v3/contacts?skip=100&top=100",
+				Done:     false,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Contacts last page resolves custom field titles and finishes",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("email", "Deal Stage"),
+				NextPage:   common.NextPageToken(testconn.URLTestServer + "/v3/contacts?skip=100&top=100"),
+			},
+			Server: mockserver.Switch{
+				Setup: mockserver.ContentJSON(),
+				Cases: mockserver.Cases{{
+					If: mockcond.And{
+						mockcond.Path("/v3/contacts"),
+						mockcond.QueryParam("skip", "100"),
+					},
+					Then: mockserver.Response(http.StatusOK, responseContactsLastPage),
+				}, {
+					If:   mockcond.Path("/v3/custom-fields"),
+					Then: mockserver.Response(http.StatusOK, responseCustomFields),
+				}},
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Id: "759458702",
+					Fields: map[string]any{
+						"email":      "jane.doe@example.com",
+						"deal stage": "probe",
+					},
+					// Raw keeps the provider's key/value shape untouched.
+					Raw: map[string]any{
+						"customFields": []any{map[string]any{
+							"key":   "150697",
+							"value": "probe",
+						}},
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Schedules is a single root-level array page",
+			Input: common.ReadParams{
+				ObjectName: "schedules",
+				Fields:     connectors.Fields("name"),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v3/schedules"),
+				Then:  mockserver.Response(http.StatusOK, responseSchedules),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Id: "559907",
+					Fields: map[string]any{
+						"name": "Default",
+					},
+					Raw: map[string]any{
+						"timezoneId": "SA Pacific Standard Time",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Sequences incremental read sends createdAfter",
+			Input: common.ReadParams{
+				ObjectName: "sequences",
+				Fields:     connectors.Fields("name"),
+				Since:      time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If: mockcond.And{
+					mockcond.Path("/v3/sequences"),
+					mockcond.QueryParam("createdAfter", "2026-01-02T03:04:05Z"),
+				},
+				Then: mockserver.ResponseString(http.StatusOK, `{"items":[],"hasMore":false}`),
+			}.Server(),
+			Comparator: testconn.ComparatorPagination,
+			Expected: &common.ReadResult{
+				Rows: 0,
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Sequences Since and Until window filters connector-side",
+			Input: common.ReadParams{
+				ObjectName: "sequences",
+				Fields:     connectors.Fields("name"),
+				Since:      time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+				// Between the two records' created times: only the earlier
+				// sequence (12:15:35) falls inside the window.
+				Until: time.Date(2026, 9, 8, 13, 0, 0, 0, time.UTC),
+			},
+			Server: mockserver.Conditional{
+				Setup: mockserver.ContentJSON(),
+				If:    mockcond.Path("/v3/sequences"),
+				Then:  mockserver.Response(http.StatusOK, responseSequences),
+			}.Server(),
+			Comparator: testconn.ComparatorSubsetRead,
+			Expected: &common.ReadResult{
+				Rows: 1,
+				Data: []common.ReadResultRow{{
+					Id: "1768686",
+					Fields: map[string]any{
+						"name": "Deep Connector Test Sequence",
+					},
+					Raw: map[string]any{
+						"created": "2026-09-08T12:15:35.52+00:00",
+					},
+				}},
+				Done: true,
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "Unauthorized problem response",
+			Input: common.ReadParams{
+				ObjectName: "contacts",
+				Fields:     connectors.Fields("email"),
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusUnauthorized, errorUnauthorized),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrAccessToken,
+				testutils.StringError("Unauthorized: Authentication credentials are missing or invalid."),
+			},
+		},
+		{
+			Name: "Validation problem response carries pointer detail",
+			Input: common.ReadParams{
+				ObjectName: "tasks",
+				Fields:     connectors.Fields("id"),
+			},
+			Server: mockserver.Fixed{
+				Setup:  mockserver.ContentJSON(),
+				Always: mockserver.Response(http.StatusBadRequest, errorValidation),
+			}.Server(),
+			ExpectedErrs: []error{
+				common.ErrBadRequest,
+				testutils.StringError("Validation failed: /top Value has an invalid type."),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.Run(t, func() (testconn.TestableReader, error) {
+				return constructTestConnector(tt.Server.URL)
+			})
+		})
+	}
+}

--- a/providers/reply/supports.go
+++ b/providers/reply/supports.go
@@ -1,0 +1,23 @@
+package reply
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/internal/components"
+	"github.com/amp-labs/connectors/providers/reply/metadata"
+)
+
+func supportedOperations() components.EndpointRegistryInput {
+	readSupport := metadata.Schemas.ObjectNames().GetList(common.ModuleRoot)
+
+	return components.EndpointRegistryInput{
+		common.ModuleRoot: {
+			{
+				Endpoint: fmt.Sprintf("{%s}", strings.Join(readSupport, ",")),
+				Support:  components.ReadSupport,
+			},
+		},
+	}
+}

--- a/providers/reply/test/read/contacts-first-page.json
+++ b/providers/reply/test/read/contacts-first-page.json
@@ -1,0 +1,35 @@
+{
+  "items": [
+    {
+      "id": 761575310,
+      "email": "john.roe@example.com",
+      "domain": "example.com",
+      "firstName": "John",
+      "lastName": "Roe",
+      "phone": "",
+      "title": "",
+      "company": null,
+      "companySize": "Empty",
+      "industry": null,
+      "city": "",
+      "state": "",
+      "country": "",
+      "timeZoneId": null,
+      "linkedInUrl": null,
+      "linkedInSalesNavigatorUrl": null,
+      "linkedInRecruiterUrl": null,
+      "phoneStatus": "notValidated",
+      "notes": null,
+      "ownerUserId": 500176,
+      "accountId": null,
+      "isOptedOut": false,
+      "callStatus": "none",
+      "meetingStatus": "none",
+      "addingDate": "2026-09-08T12:08:22.58+00:00",
+      "createdAt": null,
+      "lastModifiedAt": null,
+      "customFields": []
+    }
+  ],
+  "hasMore": true
+}

--- a/providers/reply/test/read/contacts.json
+++ b/providers/reply/test/read/contacts.json
@@ -1,0 +1,40 @@
+{
+  "items": [
+    {
+      "id": 759458702,
+      "email": "jane.doe@example.com",
+      "domain": "example.com",
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "phone": "",
+      "title": "Deep Connector Probe",
+      "company": null,
+      "companySize": "Empty",
+      "industry": null,
+      "city": "",
+      "state": "",
+      "country": "",
+      "timeZoneId": null,
+      "linkedInUrl": null,
+      "linkedInSalesNavigatorUrl": null,
+      "linkedInRecruiterUrl": null,
+      "phoneStatus": "notValidated",
+      "notes": null,
+      "ownerUserId": 500176,
+      "accountId": null,
+      "isOptedOut": false,
+      "callStatus": "none",
+      "meetingStatus": "none",
+      "addingDate": "2026-08-19T12:33:39.30+00:00",
+      "createdAt": null,
+      "lastModifiedAt": null,
+      "customFields": [
+        {
+          "key": "150697",
+          "value": "probe"
+        }
+      ]
+    }
+  ],
+  "hasMore": false
+}

--- a/providers/reply/test/read/err-unauthorized.json
+++ b/providers/reply/test/read/err-unauthorized.json
@@ -1,0 +1,1 @@
+{"title":"Unauthorized","status":401,"detail":"Authentication credentials are missing or invalid."}

--- a/providers/reply/test/read/err-validation.json
+++ b/providers/reply/test/read/err-validation.json
@@ -1,0 +1,12 @@
+{
+  "errors": [
+    {
+      "pointer": "/top",
+      "detail": "Value has an invalid type."
+    }
+  ],
+  "title": "Validation failed",
+  "status": 400,
+  "detail": "The request body contains validation errors.",
+  "extensions": {}
+}

--- a/providers/reply/test/read/schedules.json
+++ b/providers/reply/test/read/schedules.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": 559907,
+    "name": "Default",
+    "timezoneId": "SA Pacific Standard Time",
+    "excludeHolidays": false,
+    "useProspectTimezone": true,
+    "useFollowUpSchedule": false,
+    "mainTimings": [
+      {
+        "weekDay": "Sunday",
+        "isActive": false,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 0,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 24,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Monday",
+        "isActive": true,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 9,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 17,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Tuesday",
+        "isActive": true,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 9,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 17,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Wednesday",
+        "isActive": true,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 9,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 17,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Thursday",
+        "isActive": true,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 9,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 17,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Friday",
+        "isActive": true,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 9,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 17,
+              "minute": 0
+            }
+          }
+        ]
+      },
+      {
+        "weekDay": "Saturday",
+        "isActive": false,
+        "timeRanges": [
+          {
+            "fromTime": {
+              "hour": 0,
+              "minute": 0
+            },
+            "toTime": {
+              "hour": 24,
+              "minute": 0
+            }
+          }
+        ]
+      }
+    ],
+    "followUpTimings": [],
+    "isDefault": true,
+    "status": "isDefaultForCurrentUser"
+  }
+]

--- a/providers/reply/test/read/sequences.json
+++ b/providers/reply/test/read/sequences.json
@@ -1,0 +1,23 @@
+{
+  "items": [
+    {
+      "id": 1768769,
+      "name": "Deep Connector Test Sequence B",
+      "status": "new",
+      "isArchived": false,
+      "created": "2026-09-08T13:42:07.49+00:00",
+      "ownerUserId": 500176,
+      "health": "blocked"
+    },
+    {
+      "id": 1768686,
+      "name": "Deep Connector Test Sequence",
+      "status": "new",
+      "isArchived": false,
+      "created": "2026-09-08T12:15:35.52+00:00",
+      "ownerUserId": 500176,
+      "health": "blocked"
+    }
+  ],
+  "hasMore": false
+}

--- a/test/reply/read/main.go
+++ b/test/reply/read/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/amp-labs/connectors"
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/test/reply"
+	"github.com/amp-labs/connectors/test/utils"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn := reply.GetReplyConnector(ctx)
+
+	// Plain read across every supported object.
+	for _, objectName := range []string{
+		"contacts", "contact-accounts", "contact-lists", "contact-account-lists",
+		"sequences", "sequence-folders", "tasks",
+		"email-templates", "email-template-folders", "email-accounts",
+		"custom-fields", "schedules", "linkedin-accounts", "inbox/threads",
+	} {
+		readObject(ctx, conn, common.ReadParams{
+			ObjectName: objectName,
+			Fields:     connectors.Fields("id"),
+		})
+	}
+
+	// Paginated envelope object with custom field resolution.
+	readObject(ctx, conn, common.ReadParams{
+		ObjectName: "contacts",
+		Fields:     connectors.Fields("email", "firstName", "Deal Stage"),
+	})
+
+	// Root-level array object: single page.
+	readObject(ctx, conn, common.ReadParams{
+		ObjectName: "schedules",
+		Fields:     connectors.Fields("name", "timezoneId"),
+	})
+
+	// Incremental read: only sequences support a provider-side time filter.
+	readObject(ctx, conn, common.ReadParams{
+		ObjectName: "sequences",
+		Fields:     connectors.Fields("name", "created"),
+		Since:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	// Since in the future must yield zero records, proving the filter applies.
+	readObject(ctx, conn, common.ReadParams{
+		ObjectName: "sequences",
+		Fields:     connectors.Fields("name"),
+		Since:      time.Now().Add(24 * time.Hour),
+	})
+
+	// Until has no provider-side parameter; the window is enforced
+	// connector-side, so a narrow window returns only the older sequence.
+	readObject(ctx, conn, common.ReadParams{
+		ObjectName: "sequences",
+		Fields:     connectors.Fields("name", "created"),
+		Since:      time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+		Until:      time.Date(2026, 9, 8, 13, 0, 0, 0, time.UTC),
+	})
+}
+
+func readObject(ctx context.Context, conn connectors.ReadConnector, params common.ReadParams) {
+	res, err := conn.Read(ctx, params)
+	if err != nil {
+		utils.Fail("error reading from Reply", "object", params.ObjectName, "error", err)
+	}
+
+	slog.Info("Read result", "object", params.ObjectName,
+		"since", params.Since, "rows", res.Rows, "done", res.Done)
+	utils.DumpJSON(res, os.Stdout)
+}


### PR DESCRIPTION
# Description

- [x] Connector uses `internal/components`
- [x] Metadata uses V2 metadata format
- [x] Read supports pagination and incremental sync (incremental: `sequences` only — see above)
- [x] Raw response is returned as is for **READ** & **METADATA**, no formatting or flattening is performed.
- [ ] Write payloads should accept what `ReadResults.Fields` is returning.
- [x] Provider errors are mapped if non-standard
- [x] Custom fields, if not human readable names, are resolved to readable names.
- [x] Unit tests cover read logic (placed in `/providers/reply`)
- [x] live tests (placed in `/test/reply`)
- [x] Appropriate object names are used. Objects need to be resources, not actions.

# Tests

## Unit Test

<img width="1470" height="725" alt="image" src="https://github.com/user-attachments/assets/97bce038-0d44-4812-bb57-153528ecef33" />


## Live Test

<img width="1470" height="864" alt="image" src="https://github.com/user-attachments/assets/9c334bb0-bd07-4e64-b236-81ab1d548cc7" />

<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/1c441b62-790a-4623-9889-e064189571da" />

<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/75a8282b-2d6e-4ed3-85f4-d654cbaeb9fe" />

<img width="1470" height="899" alt="image" src="https://github.com/user-attachments/assets/633bca4c-432e-4b3e-b40b-6766561e486e" />

<img width="1470" height="899" alt="image" src="https://github.com/user-attachments/assets/a6e71d15-cafb-4d4a-bfd8-af28f0dc314f" />

