### PR TITLE
[CON-3515, CON-3519] feat(bambooHR): Proxy Connector

### DIFF
--- a/providers/bambooHR.go
+++ b/providers/bambooHR.go
@@ -31,12 +31,12 @@ func init() {
 		},
 		Media: &Media{
 			DarkMode: &MediaTypeDarkMode{
-				IconURL: "https://www.bamboohr.com/favicon.ico",
-				LogoURL: "https://www.bamboohr.com/favicon.ico",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1788955884/media/bamboohr.com_1788955882.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1788955924/media/bamboohr.com_1788955923.svg",
 			},
 			Regular: &MediaTypeRegular{
-				IconURL: "https://www.bamboohr.com/favicon.ico",
-				LogoURL: "https://www.bamboohr.com/favicon.ico",
+				IconURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1788955884/media/bamboohr.com_1788955882.png",
+				LogoURL: "https://res.cloudinary.com/dycvts6vp/image/upload/v1788955924/media/bamboohr.com_1788955923.svg",
 			},
 		},
 		Metadata: &ProviderMetadata{

--- a/providers/bambooHR.go
+++ b/providers/bambooHR.go
@@ -1,0 +1,54 @@
+package providers
+
+const BambooHR Provider = "bambooHR"
+
+func init() {
+	SetInfo(BambooHR, ProviderInfo{
+		DisplayName: "BambooHR",
+		AuthType:    Oauth2,
+		BaseURL:     "https://{{.workspace}}.bamboohr.com",
+		Oauth2Opts: &Oauth2Opts{
+			GrantType:                 AuthorizationCode,
+			AuthURL:                   "https://{{.workspace}}.bamboohr.com/authorize.php?request=authorize",
+			TokenURL:                  "https://{{.workspace}}.bamboohr.com/token.php?request=token",
+			ExplicitScopesRequired:    true,
+			ExplicitWorkspaceRequired: true,
+			TokenMetadataFields: TokenMetadataFields{
+				ScopesField: "scope",
+			},
+		},
+		Support: Support{
+			BulkWrite: BulkWriteSupport{
+				Insert: false,
+				Update: false,
+				Upsert: false,
+				Delete: false,
+			},
+			Proxy:     true,
+			Read:      false,
+			Subscribe: false,
+			Write:     false,
+		},
+		Media: &Media{
+			DarkMode: &MediaTypeDarkMode{
+				IconURL: "https://www.bamboohr.com/favicon.ico",
+				LogoURL: "https://www.bamboohr.com/favicon.ico",
+			},
+			Regular: &MediaTypeRegular{
+				IconURL: "https://www.bamboohr.com/favicon.ico",
+				LogoURL: "https://www.bamboohr.com/favicon.ico",
+			},
+		},
+		Metadata: &ProviderMetadata{
+			Input: []MetadataItemInput{
+				{
+					Name:        "workspace",
+					DisplayName: "Company Domain",
+					DocsURL:     "https://documentation.bamboohr.com/docs/getting-started",
+					Prompt: "The subdomain in your BambooHR login URL. " +
+						"For example, if you log in at https://mycompany.bamboohr.com, enter mycompany.",
+				},
+			},
+		},
+	})
+}

--- a/providers/bambooHR.go
+++ b/providers/bambooHR.go
@@ -6,7 +6,7 @@ func init() {
 	SetInfo(BambooHR, ProviderInfo{
 		DisplayName: "BambooHR",
 		AuthType:    Oauth2,
-		BaseURL:     "https://{{.workspace}}.bamboohr.com",
+		BaseURL:     "https://{{.workspace}}.bamboohr.com/api",
 		Oauth2Opts: &Oauth2Opts{
 			GrantType:                 AuthorizationCode,
 			AuthURL:                   "https://{{.workspace}}.bamboohr.com/authorize.php?request=authorize",

--- a/providers/bambooHR.go
+++ b/providers/bambooHR.go
@@ -24,7 +24,7 @@ func init() {
 				Upsert: false,
 				Delete: false,
 			},
-			Proxy:     true,
+			Proxy:     false,
 			Read:      false,
 			Subscribe: false,
 			Write:     false,


### PR DESCRIPTION
## Description

- Adds BambooHR to the provider catalog with OAuth 2.0 Authorization Code configuration so the connector can call BambooHR’s REST API via proxy. Proxy is enabled; Read, Write, Subscribe, and BulkWrite remain disabled.

## Summary

- Registered BambooHR in the provider registry with OAuth 2.0 Authorization Code.
- Set Base URL to `https://{{.workspace}}.bamboohr.com` (company domain is required at install time).
- Set Auth URL to `https://{{.workspace}}.bamboohr.com/authorize.php?request=authorize` and Token URL to `https://{{.workspace}}.bamboohr.com/token.php?request=token`.
- Set `ExplicitScopesRequired: true` and `ExplicitWorkspaceRequired: true` per BambooHR OAuth requirements.
- Set `TokenMetadataFields.ScopesField` to `"scope"`.
- Added input metadata `workspace` (display name: **Company Domain**) with DocsURL pointing to the [BambooHR Getting Started docs](https://documentation.bamboohr.com/docs/getting-started).
- Enabled Proxy; set Read, Write, Subscribe, and BulkWrite to false (proxy-only connector).
- Added Cloudinary Media URLs for icon and logo (dark and regular).
- Added testdata: `testdata/bambooHR/amp.yaml` and `testdata/bambooHR/proxy.http`.

## Assets

- BambooHR Logo Light: [Link](https://res.cloudinary.com/dycvts6vp/image/upload/v1788955924/media/bamboohr.com_1788955923.svg)
<img width="1679" height="376" alt="Screenshot 2026-09-10 at 7 04 49 PM" src="https://github.com/user-attachments/assets/586c4d7a-0d40-41e2-888d-e0acd123c4b2" />

- BambooHR Logo Dark: (same SVG used for dark mode) [Link](https://res.cloudinary.com/dycvts6vp/image/upload/v1788955924/media/bamboohr.com_1788955923.svg)
<img width="1679" height="376" alt="Screenshot 2026-09-10 at 7 04 49 PM" src="https://github.com/user-attachments/assets/d2deb6d9-d6a4-4b8a-bb9e-4e828e92cf0a" />

- BambooHR Icon (Regular): [Link](https://res.cloudinary.com/dycvts6vp/image/upload/v1788955884/media/bamboohr.com_1788955882.png)
<img width="184" height="187" alt="Screenshot 2026-09-10 at 7 05 29 PM" src="https://github.com/user-attachments/assets/37bc9376-634d-4ec3-8f5e-81f2930ce47a" />

## Conventions

- Provider name is camelCase: `bambooHR`
- Single module (N/A for proxy-only).
- Base URL has no version path: `https://{{.workspace}}.bamboohr.com` (API calls use `/api/v1/...` on top of this).
- DocsURL points to user-facing docs: [BambooHR API – Getting Started](https://documentation.bamboohr.com/docs/getting-started)
- Required metadata: `workspace` (Company Domain — the subdomain before `.bamboohr.com`, e.g. `mycompany` from `https://mycompany.bamboohr.com`).
- OAuth2: Authorization Code grant; scopes must be sent with the authorize request.
- Basic Auth / API key: N/A for this connector (OAuth only).
- Basic smoke: `go run scripts/catalog/json.go && go test ./providers/...`
- Integration testdata: `testdata/bambooHR/amp.yaml`, `testdata/bambooHR/proxy.http`

## GET

URL: http://localhost:4444/api/v1/employees/directory

<img width="956" height="859" alt="Screenshot 2026-09-10 at 10 29 13 PM" src="https://github.com/user-attachments/assets/771ff79b-6bc6-4958-bb33-a7cc49250a31" />


URL: http://localhost:4444/api/v1/meta/users/
<img width="966" height="858" alt="Screenshot 2026-09-10 at 10 30 55 PM" src="https://github.com/user-attachments/assets/17bdfdd7-ccfc-4132-ae83-7a51824ac1c8" />

## POST
### Create Employee
URL: http://localhost:4444/api/v1/employees
<img width="960" height="574" alt="Screenshot 2026-09-10 at 10 34 29 PM" src="https://github.com/user-attachments/assets/c3354c5b-bb50-49da-bf6f-df4420c21df4" />

### Update Employee
URL: http://localhost:4444/api/v1/employees/119
<img width="965" height="563" alt="Screenshot 2026-09-10 at 10 36 06 PM" src="https://github.com/user-attachments/assets/753b7fe2-bca9-4ab4-aa31-34c07967f1de" />
