### PR TITLE
[ENG-4236] feat(salesforce): metadata builder for workflow outbound messages (1/5)

### DIFF
--- a/providers/salesforce/internal/crm/metadata/outboundmessage.go
+++ b/providers/salesforce/internal/crm/metadata/outboundmessage.go
@@ -1,0 +1,281 @@
+package metadata
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/core"
+)
+
+// This file builds Metadata API deploy packages for Workflow Outbound Messages
+// — the delivery half of the flow-based subscription path. An outbound message
+// POSTs a SOAP notification to a configured HTTPS endpoint whenever the
+// flow that references it fires.
+
+var errOutboundMessageRequiredParams = errors.New(
+	"objectName, name, endpointURL, and integrationUsername are required")
+
+const metadataXmlns = "http://soap.sforce.com/2006/04/metadata"
+
+// OutboundMessageParams contains the parameters for constructing the deploy
+// package of one workflow outbound message.
+//
+// Field semantics mirror the WorkflowOutboundMessage metadata type; see the
+// official docs:
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_workflow.htm
+type OutboundMessageParams struct {
+	// ObjectName is the Salesforce object the outbound message belongs to
+	// (e.g., "Lead").
+	ObjectName string
+
+	// Name is the outbound message developer name WITHOUT the object prefix
+	// (e.g., "amp_Lead"). The Metadata API addresses the component as
+	// "<ObjectName>.<Name>". Use GenerateOutboundMessageNameForSubscription()
+	// to generate this.
+	Name string
+
+	// EndpointURL is where Salesforce POSTs the SOAP outbound message.
+	// Must be an HTTPS endpoint reachable from Salesforce.
+	EndpointURL string
+
+	// IntegrationUsername is the Salesforce username whose permissions the
+	// outbound message payload is evaluated under.
+	IntegrationUsername string
+
+	// Fields lists the object fields included in the outbound message payload.
+	// Id, CreatedDate, and LastModifiedDate are always included on top of
+	// whatever the caller lists: Id is how consumers fetch the full record, and the
+	// audit timestamps let the event parser infer create vs update.
+	Fields []string
+}
+
+// GenerateOutboundMessageNameForSubscription returns the outbound message
+// developer name for a given Salesforce object. Developer names must not
+// contain consecutive underscores, so custom-object suffixes like "__c" are collapsed
+// (e.g. "My_Object__c" → "amp_My_Object_c").
+func GenerateOutboundMessageNameForSubscription(objectName string) (string, error) {
+	if objectName == "" {
+		return "", errEmptyObjectName
+	}
+
+	return "amp_" + sanitizeDeveloperName(objectName), nil
+}
+
+// OutboundMessageFullName returns the Metadata API full name of the outbound
+// message component, which is prefixed by the object it belongs to.
+func OutboundMessageFullName(objectName, outboundMessageName string) string {
+	return objectName + "." + outboundMessageName
+}
+
+// sanitizeDeveloperName converts an object API name into a string that is
+// valid inside a developer name: consecutive underscores collapse to one and
+// trailing underscores are trimmed.
+func sanitizeDeveloperName(name string) string {
+	for strings.Contains(name, "__") {
+		name = strings.ReplaceAll(name, "__", "_")
+	}
+
+	return strings.Trim(name, "_")
+}
+
+// ValidateOutboundMessageParams checks that all required fields are present.
+func ValidateOutboundMessageParams(params OutboundMessageParams) error {
+	if params.ObjectName == "" || params.Name == "" ||
+		params.EndpointURL == "" || params.IntegrationUsername == "" {
+		return errOutboundMessageRequiredParams
+	}
+
+	return nil
+}
+
+// The XML structs below mirror the Metadata API WSDL. Element order matters:
+// Salesforce validates deploy XML against an XSD sequence, so struct fields
+// are declared in the order a metadata retrieve produces them.
+//
+// Official field reference and example XML for Workflow / WorkflowOutboundMessage:
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_workflow.htm
+
+type workflowOutboundMessageXML struct {
+	FullName           string   `xml:"fullName"`
+	APIVersion         string   `xml:"apiVersion"`
+	Description        string   `xml:"description"`
+	EndpointURL        string   `xml:"endpointUrl"`
+	Fields             []string `xml:"fields"`
+	IncludeSessionID   bool     `xml:"includeSessionId"`
+	IntegrationUser    string   `xml:"integrationUser"`
+	Name               string   `xml:"name"`
+	Protected          bool     `xml:"protected"`
+	UseDeadLetterQueue bool     `xml:"useDeadLetterQueue"`
+}
+
+type workflowXML struct {
+	XMLName          xml.Name                     `xml:"Workflow"`
+	Xmlns            string                       `xml:"xmlns,attr"`
+	OutboundMessages []workflowOutboundMessageXML `xml:"outboundMessages"`
+}
+
+// ensureOutboundMessageFields returns the caller's field list with Id,
+// CreatedDate, and LastModifiedDate guaranteed present (prepended when
+// missing, original order otherwise preserved). Every standard and custom
+// object carries these audit fields; forcing them keeps the payload usable
+// downstream — Id for record fetch, the timestamps for create-vs-update
+// inference — regardless of what the caller configured.
+func ensureOutboundMessageFields(fields []string) []string {
+	required := []string{"Id", "CreatedDate", "LastModifiedDate"}
+
+	present := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		present[field] = true
+	}
+
+	missing := make([]string, 0, len(required))
+
+	for _, field := range required {
+		if !present[field] {
+			missing = append(missing, field)
+		}
+	}
+
+	return append(missing, fields...)
+}
+
+// generateWorkflowXML returns the workflows/<Object>.workflow file content
+// carrying the single outbound message component.
+func generateWorkflowXML(params OutboundMessageParams) (string, error) {
+	fields := ensureOutboundMessageFields(params.Fields)
+
+	workflow := workflowXML{
+		Xmlns: metadataXmlns,
+		OutboundMessages: []workflowOutboundMessageXML{
+			{
+				FullName:   params.Name,
+				APIVersion: core.APIVersion,
+				Description: "THIS IS AN AUTOMATED OUTBOUND MESSAGE. DO NOT EDIT. " +
+					"It delivers subscription events for the object to Ampersand.",
+				EndpointURL:      params.EndpointURL,
+				Fields:           fields,
+				IncludeSessionID: false,
+				IntegrationUser:  params.IntegrationUsername,
+				Name:             params.Name,
+				Protected:        false,
+				// Salesforce retries failed deliveries for up to 24 hours on
+				// its own; the dead letter queue is unnecessary for our
+				// at-least-once pipeline.
+				UseDeadLetterQueue: false,
+			},
+		},
+	}
+
+	out, err := xml.MarshalIndent(workflow, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal workflow XML: %w", err)
+	}
+
+	return xml.Header + string(out) + "\n", nil
+}
+
+// ConstructOutboundMessage builds a zip containing only the workflow outbound
+// message for one object. Subscribe combines this with flow metadata into one
+// Metadata API package; Salesforce resolves the flow→OM reference in that
+// single deploy.
+func ConstructOutboundMessage(params OutboundMessageParams) ([]byte, error) {
+	if err := ValidateOutboundMessageParams(params); err != nil {
+		return nil, err
+	}
+
+	workflowContent, err := generateWorkflowXML(params)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types: []triggerPackageType{
+			{
+				Members: []string{OutboundMessageFullName(params.ObjectName, params.Name)},
+				Name:    "WorkflowOutboundMessage",
+			},
+		},
+	}
+
+	pkgXML, err := xml.MarshalIndent(pkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package.xml: %w", err)
+	}
+
+	return buildZip(map[string][]byte{
+		"package.xml": []byte(xml.Header + string(pkgXML)),
+		"workflows/" + params.ObjectName + ".workflow": []byte(workflowContent),
+	})
+}
+
+// ConstructDestructiveOutboundMessage builds a zipped destructive changes
+// package that removes the outbound message. Deploy this AFTER every
+// flow that references it is gone.
+//
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy_deleting_files.htm
+func ConstructDestructiveOutboundMessage(objectName, outboundMessageName string) ([]byte, error) {
+	if objectName == "" || outboundMessageName == "" {
+		return nil, errEmptyObjectName
+	}
+
+	return constructDestructiveZip(triggerPackageType{
+		Members: []string{OutboundMessageFullName(objectName, outboundMessageName)},
+		Name:    "WorkflowOutboundMessage",
+	})
+}
+
+// constructDestructiveZip builds a destructive-changes zip for the given
+// package types with the empty package.xml required by the Metadata API.
+func constructDestructiveZip(types ...triggerPackageType) ([]byte, error) {
+	emptyPkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types:   []triggerPackageType{},
+	}
+
+	emptyPkgXML, err := xml.MarshalIndent(emptyPkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal empty package.xml: %w", err)
+	}
+
+	destructivePkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types:   types,
+	}
+
+	destructiveXML, err := xml.MarshalIndent(destructivePkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal destructiveChanges.xml: %w", err)
+	}
+
+	return buildZip(map[string][]byte{
+		"package.xml":            []byte(xml.Header + string(emptyPkgXML)),
+		"destructiveChanges.xml": []byte(xml.Header + string(destructiveXML)),
+	})
+}
+
+// buildZip writes the given name→content entries into an in-memory zip.
+func buildZip(entries map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+
+	zipWriter := zip.NewWriter(&buf)
+
+	for name, content := range entries {
+		if err := addTriggerToZip(zipWriter, name, content); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close zip writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/providers/salesforce/internal/crm/metadata/outboundmessage_test.go
+++ b/providers/salesforce/internal/crm/metadata/outboundmessage_test.go
@@ -1,0 +1,231 @@
+package metadata
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestGenerateOutboundMessageNameForSubscription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		object    string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "Standard object",
+			object:   "Account",
+			expected: "amp_Account",
+		},
+		{
+			name:     "Custom object collapses consecutive underscores",
+			object:   "My_Object__c",
+			expected: "amp_My_Object_c",
+		},
+		{
+			name:      "Empty object name returns error",
+			object:    "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GenerateOutboundMessageNameForSubscription(tt.object)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.expected {
+				t.Errorf("GenerateOutboundMessageNameForSubscription(%q) = %q, want %q", tt.object, got, tt.expected)
+			}
+		})
+	}
+}
+
+func validOutboundMessageParams() OutboundMessageParams {
+	return OutboundMessageParams{
+		ObjectName:          "Account",
+		Name:                "amp_Account",
+		EndpointURL:         "https://example.com/webhook",
+		IntegrationUsername: "integration@example.com",
+	}
+}
+
+// readZipEntries unpacks an in-memory zip into name → content.
+func readZipEntries(t *testing.T, zipData []byte) map[string]string {
+	t.Helper()
+
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		t.Fatalf("failed to open zip: %v", err)
+	}
+
+	entries := make(map[string]string)
+
+	for _, file := range reader.File {
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("failed to open zip entry %s: %v", file.Name, err)
+		}
+
+		content, err := io.ReadAll(rc)
+		rc.Close()
+
+		if err != nil {
+			t.Fatalf("failed to read zip entry %s: %v", file.Name, err)
+		}
+
+		entries[file.Name] = string(content)
+	}
+
+	return entries
+}
+
+func TestConstructOutboundMessage(t *testing.T) {
+	t.Parallel()
+
+	params := validOutboundMessageParams()
+	params.Fields = []string{"Id", "Name"}
+
+	zipData, err := ConstructOutboundMessage(params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	pkg, ok := entries["package.xml"]
+	if !ok {
+		t.Fatalf("package.xml missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<name>WorkflowOutboundMessage</name>",
+		"<members>Account.amp_Account</members>",
+	} {
+		if !strings.Contains(pkg, want) {
+			t.Errorf("package.xml missing %q:\n%s", want, pkg)
+		}
+	}
+
+	workflow, ok := entries["workflows/Account.workflow"]
+	if !ok {
+		t.Fatalf("workflow file missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<fullName>amp_Account</fullName>",
+		"<endpointUrl>https://example.com/webhook</endpointUrl>",
+		"<integrationUser>integration@example.com</integrationUser>",
+		"<fields>Id</fields>",
+		"<fields>Name</fields>",
+		"<includeSessionId>false</includeSessionId>",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("workflow XML missing %q:\n%s", want, workflow)
+		}
+	}
+}
+
+func TestConstructOutboundMessageAlwaysIncludesRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	// No fields configured: the required set alone makes up the payload.
+	zipData, err := ConstructOutboundMessage(validOutboundMessageParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	for _, want := range []string{
+		"<fields>Id</fields>",
+		"<fields>CreatedDate</fields>",
+		"<fields>LastModifiedDate</fields>",
+	} {
+		if !strings.Contains(entries["workflows/Account.workflow"], want) {
+			t.Errorf("workflow XML missing required field %q", want)
+		}
+	}
+
+	// Caller-configured fields must not displace the required set, and must
+	// not be duplicated when they overlap with it.
+	params := validOutboundMessageParams()
+	params.Fields = []string{"Name", "CreatedDate"}
+
+	zipData, err = ConstructOutboundMessage(params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	workflow := readZipEntries(t, zipData)["workflows/Account.workflow"]
+
+	for _, want := range []string{
+		"<fields>Id</fields>",
+		"<fields>LastModifiedDate</fields>",
+		"<fields>Name</fields>",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("workflow XML missing field %q:\n%s", want, workflow)
+		}
+	}
+
+	if strings.Count(workflow, "<fields>CreatedDate</fields>") != 1 {
+		t.Errorf("CreatedDate must appear exactly once:\n%s", workflow)
+	}
+}
+
+func TestConstructDestructiveOutboundMessage(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructDestructiveOutboundMessage("Account", "amp_Account")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	destructive, ok := entries["destructiveChanges.xml"]
+	if !ok {
+		t.Fatalf("destructiveChanges.xml missing; entries: %v", keysOf(entries))
+	}
+
+	if !strings.Contains(destructive, "<members>Account.amp_Account</members>") ||
+		!strings.Contains(destructive, "<name>WorkflowOutboundMessage</name>") {
+		t.Errorf("destructiveChanges.xml missing outbound message member:\n%s", destructive)
+	}
+
+	pkg, ok := entries["package.xml"]
+	if !ok {
+		t.Fatal("destructive zip requires package.xml")
+	}
+
+	if strings.Contains(pkg, "<types>") || strings.Contains(pkg, "<members>") {
+		t.Errorf("package.xml must list no components to deploy:\n%s", pkg)
+	}
+}
+
+func keysOf(entries map[string]string) []string {
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+
+	return keys
+}


### PR DESCRIPTION
This is a purely additive PR, the first in a stack building Salesforce Subscribe using Flows ([proposal)](https://app.notion.com/p/Salesforce-Subscribe-via-Record-Triggered-Flow-Outbound-Messages-3cf1a75bd39681799c81f7fcb59278e2). 

This new Salesforce Subscribe mechanism deploys one metadata API package containing one `package.xml` that lists `WorkflowOutboundMessage` and `Flow` members, plus the files (`workflows/*.workflow` and `flows/*.flow`). In this PR we build Salesforce Metadata API zips for Workflow Outbound Messages.

This has been manually tested by script at the top of the PR stack. Deploying the metadata package produces OMs in my org. Subscribe works and sends SOAP notifications to the endpoint configured on the OM. Teardown successfully removes the OMs. 
<img width="2253" height="474" alt="Screenshot 2026-09-09 at 1 44 42 PM" src="https://github.com/user-attachments/assets/24515e5c-b9be-45a5-985f-8329991ab4b1" />
