### PR TITLE
[ENG-4236] feat(salesforce): metadata builder for subscription record-triggered flows (2/8)

### DIFF
--- a/providers/salesforce/internal/crm/metadata/flowsubscription.go
+++ b/providers/salesforce/internal/crm/metadata/flowsubscription.go
@@ -1,0 +1,394 @@
+package metadata
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/core"
+)
+
+// This file builds Metadata API deploy packages for the record-triggered Flow
+// of a flow-based subscription. The flow fires after a record is created
+// and/or updated and invokes a Workflow Outbound Message action, which POSTs
+// a SOAP notification to the configured endpoint.
+//
+// DELETE events are not supported on this path: record-triggered delete flows
+// run before-delete and do not support the outbound message action.
+
+var (
+	errFlowRequiredParams = errors.New(
+		"objectName, flowName, and outboundMessageName are required")
+	errFlowInvalidTriggerType = errors.New(
+		"recordTriggerType must be Create, Update, or CreateAndUpdate")
+	errNoFlowComponents = errors.New(
+		"at least one flow subscription component is required")
+)
+
+// FlowSubscriptionComponent pairs the two artifacts deployed for one object
+// of a flow-based subscription: the workflow outbound message and the
+// record-triggered flow that invokes it.
+type FlowSubscriptionComponent struct {
+	OutboundMessage OutboundMessageParams
+	Flow            FlowParams
+}
+
+// validateFlowSubscriptionComponent checks one OM+flow pair before it is added
+// to the combined subscribe zip: both param sets are valid, they name the same
+// object and outbound message, and that object is not already in the package.
+func validateFlowSubscriptionComponent(
+	component FlowSubscriptionComponent, seenObjects map[string]bool,
+) error {
+	omParams, flowParams := component.OutboundMessage, component.Flow
+
+	if err := ValidateOutboundMessageParams(omParams); err != nil {
+		return err
+	}
+
+	if err := ValidateFlowParams(flowParams); err != nil {
+		return err
+	}
+
+	if omParams.ObjectName != flowParams.ObjectName || omParams.Name != flowParams.OutboundMessageName {
+		return fmt.Errorf("%w: outbound message %s.%s does not match flow reference %s.%s",
+			errFlowRequiredParams,
+			omParams.ObjectName, omParams.Name,
+			flowParams.ObjectName, flowParams.OutboundMessageName)
+	}
+
+	if seenObjects[omParams.ObjectName] {
+		return fmt.Errorf("%w: duplicate object %s", errFlowRequiredParams, omParams.ObjectName)
+	}
+
+	return nil
+}
+
+// RecordTriggerType maps to Flow.start.recordTriggerType in the Metadata API
+// (Create, Update, CreateAndUpdate). We do not use Delete: record-triggered
+// delete flows cannot invoke an outbound message.
+type RecordTriggerType string
+
+const (
+	RecordTriggerTypeCreate          RecordTriggerType = "Create"
+	RecordTriggerTypeUpdate          RecordTriggerType = "Update"
+	RecordTriggerTypeCreateAndUpdate RecordTriggerType = "CreateAndUpdate"
+)
+
+// FlowParams contains the parameters for constructing the deploy package of
+// one record-triggered flow that invokes an outbound message.
+// See the official docs (with declaration details and example XML):
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_visual_workflow.htm
+type FlowParams struct {
+	// ObjectName is the Salesforce object the flow runs on (e.g., "Lead").
+	ObjectName string
+
+	// FlowName is the Flow API name (e.g., "acme_Lead").
+	FlowName string
+
+	// OutboundMessageName is the developer name (WITHOUT the object prefix)
+	// of the outbound message the flow invokes.
+	OutboundMessageName string
+
+	// RecordTriggerType selects when the flow fires (Create / Update /
+	// CreateAndUpdate).
+	RecordTriggerType RecordTriggerType
+
+	// WatchFields optionally narrows when the flow runs via an entry-condition
+	// formula.
+	WatchFields []string
+}
+
+// ValidateFlowParams checks that all required fields are present and the
+// trigger type is valid.
+func ValidateFlowParams(params FlowParams) error {
+	if params.ObjectName == "" || params.FlowName == "" || params.OutboundMessageName == "" {
+		return errFlowRequiredParams
+	}
+
+	switch params.RecordTriggerType {
+	case RecordTriggerTypeCreate, RecordTriggerTypeUpdate, RecordTriggerTypeCreateAndUpdate:
+		return nil
+	default:
+		return fmt.Errorf("%w: got %q", errFlowInvalidTriggerType, params.RecordTriggerType)
+	}
+}
+
+// The XML structs below mirror the Metadata API WSDL. Element order matters:
+// Salesforce validates deploy XML against an XSD sequence, so struct fields
+// are declared in the order a metadata retrieve produces them.
+//
+// Official field reference and example XML for Flow (incl. FlowActionCall,
+// FlowStart, and the outboundMessage action type):
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_visual_workflow.htm
+
+type flowActionCallXML struct {
+	Name                 string `xml:"name"`
+	Label                string `xml:"label"`
+	LocationX            int    `xml:"locationX"`
+	LocationY            int    `xml:"locationY"`
+	ActionName           string `xml:"actionName"`
+	ActionType           string `xml:"actionType"`
+	FlowTransactionModel string `xml:"flowTransactionModel"`
+	NameSegment          string `xml:"nameSegment"`
+}
+
+type flowConnectorXML struct {
+	TargetReference string `xml:"targetReference"`
+}
+
+type flowStartXML struct {
+	LocationX         int               `xml:"locationX"`
+	LocationY         int               `xml:"locationY"`
+	Connector         *flowConnectorXML `xml:"connector,omitempty"`
+	FilterFormula     string            `xml:"filterFormula,omitempty"`
+	Object            string            `xml:"object"`
+	RecordTriggerType string            `xml:"recordTriggerType"`
+	TriggerType       string            `xml:"triggerType"`
+}
+
+type flowXML struct {
+	XMLName        xml.Name          `xml:"Flow"`
+	Xmlns          string            `xml:"xmlns,attr"`
+	ActionCalls    flowActionCallXML `xml:"actionCalls"`
+	APIVersion     string            `xml:"apiVersion"`
+	Environments   string            `xml:"environments"`
+	InterviewLabel string            `xml:"interviewLabel"`
+	Label          string            `xml:"label"`
+	ProcessType    string            `xml:"processType"`
+	Start          flowStartXML      `xml:"start"`
+	Status         string            `xml:"status"`
+}
+
+// flowSendActionName is the flow element name of the single outbound message
+// action call inside a generated flow.
+const flowSendActionName = "Send_Outbound_Message"
+
+// GenerateFlowXML returns the .flow file content for the record-triggered
+// flow of a flow-based subscription: a single after-save start element wired
+// to one outbound message action call. Status is "Active" on subscribe and
+// "Draft" on the deactivation fallback.
+func GenerateFlowXML(params FlowParams, status string) (string, error) {
+	omFullName := OutboundMessageFullName(params.ObjectName, params.OutboundMessageName)
+
+	flow := flowXML{
+		Xmlns: metadataXmlns,
+		ActionCalls: flowActionCallXML{
+			Name:       flowSendActionName,
+			Label:      "Send Outbound Message",
+			LocationX:  176, //nolint:mnd // canvas coordinates; arbitrary but required
+			LocationY:  287, //nolint:mnd
+			ActionName: omFullName,
+			ActionType: "outboundMessage",
+			// CurrentTransaction sends the message when the trigger's
+			// transaction commits — a rolled-back save sends nothing.
+			FlowTransactionModel: "CurrentTransaction",
+			NameSegment:          omFullName,
+		},
+		APIVersion:     core.APIVersion,
+		Environments:   "Default",
+		InterviewLabel: params.FlowName + " {!$Flow.CurrentDateTime}",
+		Label:          params.FlowName,
+		ProcessType:    "AutoLaunchedFlow",
+		Start: flowStartXML{
+			LocationX:         50, //nolint:mnd
+			LocationY:         0,
+			Connector:         &flowConnectorXML{TargetReference: flowSendActionName},
+			FilterFormula:     buildWatchFieldsFilterFormula(params),
+			Object:            params.ObjectName,
+			RecordTriggerType: string(params.RecordTriggerType),
+			TriggerType:       "RecordAfterSave",
+		},
+		Status: status,
+	}
+
+	out, err := xml.MarshalIndent(flow, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal flow XML: %w", err)
+	}
+
+	return xml.Header + string(out) + "\n", nil
+}
+
+// buildWatchFieldsFilterFormula returns the flow entry-condition formula that
+// applies WatchFields, or "" when none are configured or the trigger is
+// Create-only.
+//
+// Salesforce does not allow a bare ISCHANGED() entry condition on flows that
+// fire on create: there is no prior value, the Is Changed operator is
+// documented as update-only, and ISCHANGED() on create fails as working as
+// expected:
+//
+//	https://help.salesforce.com/s/articleView?id=platform.flow_ref_elements_start_object.htm
+//	https://help.salesforce.com/s/issue?id=a028c00000j5k7eAAA
+//
+// For CreateAndUpdate, use OR with ISNEW() so creates still notify and updates
+// stay gated on watched fields — the documented pattern:
+//
+//	https://admin.salesforce.com/blog/2022/three-powerful-formula-functions-you-can-use-in-flow
+func buildWatchFieldsFilterFormula(params FlowParams) string {
+	if len(params.WatchFields) == 0 || params.RecordTriggerType == RecordTriggerTypeCreate {
+		return ""
+	}
+
+	changed := make([]string, 0, len(params.WatchFields))
+	for _, field := range params.WatchFields {
+		changed = append(changed, fmt.Sprintf("ISCHANGED({!$Record.%s})", field))
+	}
+
+	if params.RecordTriggerType == RecordTriggerTypeCreateAndUpdate {
+		return "OR(ISNEW(), " + strings.Join(changed, ", ") + ")"
+	}
+
+	if len(changed) == 1 {
+		return changed[0]
+	}
+
+	return "OR(" + strings.Join(changed, ", ") + ")"
+}
+
+// ConstructDraftFlow builds an UPDATE zip with status Draft so the flow is
+// deactivated. Salesforce refuses to delete an Active flow, so teardown
+// deactivates first. Prefer Tooling API PATCH of FlowDefinition
+// (activeVersionNumber=0): it skips the org-wide Metadata deploy queue, does
+// not create a new flow version, and does not need this XML rebuilt. Use this
+// zip only when that PATCH fails. After the flow is inactive,
+// ConstructDestructiveFlow removes the versions from the org.
+func ConstructDraftFlow(params FlowParams) ([]byte, error) {
+	if err := ValidateFlowParams(params); err != nil {
+		return nil, err
+	}
+
+	flowContent, err := GenerateFlowXML(params, "Draft")
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types: []triggerPackageType{
+			{
+				Members: []string{params.FlowName},
+				Name:    "Flow",
+			},
+		},
+	}
+
+	pkgXML, err := xml.MarshalIndent(pkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package.xml: %w", err)
+	}
+
+	return buildZip(map[string][]byte{
+		"package.xml":                        []byte(xml.Header + string(pkgXML)),
+		"flows/" + params.FlowName + ".flow": []byte(flowContent),
+	})
+}
+
+// FlowVersionMember returns the Metadata API member for one flow version
+// (e.g. acme_Account-2). Destructive deploys must use this form:
+// an unversioned Flow member fails with "insufficient access rights on
+// cross-reference id" once a definition has more than one version
+// (Salesforce known issue):
+// https://help.salesforce.com/s/issue?id=a028c00000gAwixAAC
+func FlowVersionMember(flowName string, version int) string {
+	return fmt.Sprintf("%s-%d", flowName, version)
+}
+
+// ConstructDestructiveFlow builds a DELETE zip for the given flow versions
+// (destructiveChanges.xml; no .flow file). The flow must already be inactive
+// (Tooling or ConstructDraftFlow). Members are version-suffixed; see FlowVersionMember.
+func ConstructDestructiveFlow(flowName string, versions []int) ([]byte, error) {
+	if flowName == "" {
+		return nil, errEmptyObjectName
+	}
+
+	if len(versions) == 0 {
+		return nil, errNoFlowComponents
+	}
+
+	members := make([]string, 0, len(versions))
+	for _, version := range versions {
+		members = append(members, FlowVersionMember(flowName, version))
+	}
+
+	return constructDestructiveZip(triggerPackageType{
+		Members: members,
+		Name:    "Flow",
+	})
+}
+
+// ConstructFlowSubscription builds ONE deploy package for a flow-based
+// subscription: every component's workflow outbound message and Active
+// record-triggered flow. Salesforce metadata deploys are atomic per package
+// (our deploy options set rollbackOnError=true) — either every component
+// lands or none do — so an entire subscription costs ONE deploy() call and
+// one status poll regardless of object count, and a failed deploy leaves
+// nothing to tear down.
+//
+// No dependency declaration is needed: Salesforce resolves references between
+// components of the same deployment automatically — the flow's actionName reference
+// to the outbound message is satisfied because the outbound message ships in the same
+// package. See "Deploying and Retrieving Metadata":
+// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm
+func ConstructFlowSubscription(components []FlowSubscriptionComponent) ([]byte, error) {
+	if len(components) == 0 {
+		return nil, errNoFlowComponents
+	}
+
+	entries := make(map[string][]byte, 2*len(components)+1) //nolint:mnd
+	omMembers := make([]string, 0, len(components))
+	flowMembers := make([]string, 0, len(components))
+	seenObjects := make(map[string]bool, len(components))
+
+	for _, component := range components {
+		omParams, flowParams := component.OutboundMessage, component.Flow
+
+		if err := validateFlowSubscriptionComponent(component, seenObjects); err != nil {
+			return nil, err
+		}
+
+		seenObjects[omParams.ObjectName] = true
+
+		workflowContent, err := generateWorkflowXML(omParams)
+		if err != nil {
+			return nil, err
+		}
+
+		flowContent, err := GenerateFlowXML(flowParams, "Active")
+		if err != nil {
+			return nil, err
+		}
+
+		entries["workflows/"+omParams.ObjectName+".workflow"] = []byte(workflowContent)
+		entries["flows/"+flowParams.FlowName+".flow"] = []byte(flowContent)
+
+		omMembers = append(omMembers, OutboundMessageFullName(omParams.ObjectName, omParams.Name))
+		flowMembers = append(flowMembers, flowParams.FlowName)
+	}
+
+	pkg := triggerPackageXML{
+		Xmlns:   metadataXmlns,
+		Version: core.APIVersion,
+		Types: []triggerPackageType{
+			{
+				Members: omMembers,
+				Name:    "WorkflowOutboundMessage",
+			},
+			{
+				Members: flowMembers,
+				Name:    "Flow",
+			},
+		},
+	}
+
+	pkgXML, err := xml.MarshalIndent(pkg, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package.xml: %w", err)
+	}
+
+	entries["package.xml"] = []byte(xml.Header + string(pkgXML))
+
+	return buildZip(entries)
+}

--- a/providers/salesforce/internal/crm/metadata/flowsubscription_test.go
+++ b/providers/salesforce/internal/crm/metadata/flowsubscription_test.go
@@ -1,0 +1,239 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+)
+
+func validFlowParams() FlowParams {
+	return FlowParams{
+		ObjectName:          "Account",
+		FlowName:            "acme_Account",
+		OutboundMessageName: "amp_Account",
+		RecordTriggerType:   RecordTriggerTypeCreateAndUpdate,
+	}
+}
+
+func TestValidateFlowParamsRejectsDelete(t *testing.T) {
+	t.Parallel()
+
+	params := validFlowParams()
+	params.RecordTriggerType = "Delete"
+
+	if err := ValidateFlowParams(params); err == nil {
+		t.Error("expected error for Delete trigger; outbound messages cannot run on delete")
+	}
+}
+
+func TestBuildWatchFieldsFilterFormula(t *testing.T) {
+	t.Parallel()
+
+	params := validFlowParams()
+	params.RecordTriggerType = RecordTriggerTypeUpdate
+	params.WatchFields = []string{"Email"}
+
+	if got := buildWatchFieldsFilterFormula(params); got != "ISCHANGED({!$Record.Email})" {
+		t.Errorf("single watch field formula = %q", got)
+	}
+
+	params.WatchFields = []string{"Email", "Phone"}
+
+	expected := "OR(ISCHANGED({!$Record.Email}), ISCHANGED({!$Record.Phone}))"
+	if got := buildWatchFieldsFilterFormula(params); got != expected {
+		t.Errorf("multi watch field formula = %q, want %q", got, expected)
+	}
+
+	// Create+update: ISNEW so creates still fire; ISCHANGED gates updates.
+	params.RecordTriggerType = RecordTriggerTypeCreateAndUpdate
+	wantCreateAndUpdate := "OR(ISNEW(), ISCHANGED({!$Record.Email}), ISCHANGED({!$Record.Phone}))"
+	if got := buildWatchFieldsFilterFormula(params); got != wantCreateAndUpdate {
+		t.Errorf("CreateAndUpdate formula = %q, want %q", got, wantCreateAndUpdate)
+	}
+
+	params.RecordTriggerType = RecordTriggerTypeCreate
+	if got := buildWatchFieldsFilterFormula(params); got != "" {
+		t.Errorf("expected no formula for Create-only, got %q", got)
+	}
+
+	params.RecordTriggerType = RecordTriggerTypeUpdate
+	params.WatchFields = nil
+
+	if got := buildWatchFieldsFilterFormula(params); got != "" {
+		t.Errorf("expected no formula without watch fields, got %q", got)
+	}
+}
+
+func TestConstructDraftFlow(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructDraftFlow(validFlowParams())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	pkg, ok := entries["package.xml"]
+	if !ok {
+		t.Fatalf("package.xml missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<name>Flow</name>",
+		"<members>acme_Account</members>",
+	} {
+		if !strings.Contains(pkg, want) {
+			t.Errorf("package.xml missing %q:\n%s", want, pkg)
+		}
+	}
+
+	if strings.Contains(pkg, "WorkflowOutboundMessage") {
+		t.Errorf("draft zip must not carry the outbound message:\n%s", pkg)
+	}
+
+	if _, exists := entries["workflows/Account.workflow"]; exists {
+		t.Error("draft zip must not carry the workflow file")
+	}
+
+	flow, ok := entries["flows/acme_Account.flow"]
+	if !ok {
+		t.Fatalf("flow file missing; entries: %v", keysOf(entries))
+	}
+
+	for _, want := range []string{
+		"<actionName>Account.amp_Account</actionName>",
+		"<actionType>outboundMessage</actionType>",
+		"<object>Account</object>",
+		"<recordTriggerType>CreateAndUpdate</recordTriggerType>",
+		"<triggerType>RecordAfterSave</triggerType>",
+		"<status>Draft</status>",
+		"<processType>AutoLaunchedFlow</processType>",
+	} {
+		if !strings.Contains(flow, want) {
+			t.Errorf("flow XML missing %q:\n%s", want, flow)
+		}
+	}
+
+	if strings.Contains(flow, "<filterFormula>") {
+		t.Errorf("flow XML must not carry a filter formula without watch fields:\n%s", flow)
+	}
+}
+
+func TestConstructDestructiveFlow(t *testing.T) {
+	t.Parallel()
+
+	zipData, err := ConstructDestructiveFlow("acme_Account", []int{1, 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	destructive := readZipEntries(t, zipData)["destructiveChanges.xml"]
+	for _, want := range []string{
+		"<members>acme_Account-1</members>",
+		"<members>acme_Account-2</members>",
+		"<name>Flow</name>",
+	} {
+		if !strings.Contains(destructive, want) {
+			t.Errorf("destructiveChanges.xml missing %q:\n%s", want, destructive)
+		}
+	}
+
+	if _, err := ConstructDestructiveFlow("acme_Account", nil); err == nil {
+		t.Error("expected error for empty version list")
+	}
+}
+
+// subscriptionComponentFor builds a consistent component for the given object.
+func subscriptionComponentFor(objectName string) FlowSubscriptionComponent {
+	omName := "amp_" + objectName
+	flowName := "acme_" + objectName
+
+	return FlowSubscriptionComponent{
+		OutboundMessage: OutboundMessageParams{
+			ObjectName:          objectName,
+			Name:                omName,
+			EndpointURL:         "https://example.com/webhook",
+			IntegrationUsername: "integration@example.com",
+		},
+		Flow: FlowParams{
+			ObjectName:          objectName,
+			FlowName:            flowName,
+			OutboundMessageName: omName,
+			RecordTriggerType:   RecordTriggerTypeCreateAndUpdate,
+		},
+	}
+}
+
+func TestConstructFlowSubscription(t *testing.T) {
+	t.Parallel()
+
+	// The whole subscription (multiple objects) ships as ONE package.
+	zipData, err := ConstructFlowSubscription([]FlowSubscriptionComponent{
+		subscriptionComponentFor("Account"),
+		subscriptionComponentFor("Contact"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := readZipEntries(t, zipData)
+
+	pkg := entries["package.xml"]
+	for _, want := range []string{
+		"<name>WorkflowOutboundMessage</name>",
+		"<members>Account.amp_Account</members>",
+		"<members>Contact.amp_Contact</members>",
+		"<name>Flow</name>",
+		"<members>acme_Account</members>",
+		"<members>acme_Contact</members>",
+	} {
+		if !strings.Contains(pkg, want) {
+			t.Errorf("package.xml missing %q:\n%s", want, pkg)
+		}
+	}
+
+	for _, file := range []string{
+		"workflows/Account.workflow",
+		"workflows/Contact.workflow",
+		"flows/acme_Account.flow",
+		"flows/acme_Contact.flow",
+	} {
+		if _, ok := entries[file]; !ok {
+			t.Errorf("package missing %s; entries: %v", file, keysOf(entries))
+		}
+	}
+
+	if !strings.Contains(entries["flows/acme_Account.flow"], "<status>Active</status>") {
+		t.Error("package must deploy flows as Active")
+	}
+}
+
+func TestConstructFlowSubscriptionValidation(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ConstructFlowSubscription(nil); err == nil {
+		t.Error("expected error for empty component list")
+	}
+
+	mismatchedName := subscriptionComponentFor("Account")
+	mismatchedName.Flow.OutboundMessageName = "amp_Other"
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{mismatchedName}); err == nil {
+		t.Error("expected error for outbound message name mismatch")
+	}
+
+	mismatchedObject := subscriptionComponentFor("Account")
+	mismatchedObject.Flow.ObjectName = "Contact"
+	mismatchedObject.Flow.FlowName = "acme_Contact"
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{mismatchedObject}); err == nil {
+		t.Error("expected error for object name mismatch")
+	}
+
+	if _, err := ConstructFlowSubscription([]FlowSubscriptionComponent{
+		subscriptionComponentFor("Account"),
+		subscriptionComponentFor("Account"),
+	}); err == nil {
+		t.Error("expected error for duplicate object")
+	}
+}

--- a/providers/salesforce/internal/crm/metadata/nameprefix.go
+++ b/providers/salesforce/internal/crm/metadata/nameprefix.go
@@ -1,0 +1,86 @@
+package metadata
+
+import (
+	"strings"
+)
+
+// developerNameMaxLength is Salesforce's cap on a Flow API name and an outbound
+// message developer name.
+const developerNameMaxLength = 80
+
+// DefaultNamePrefix names artifacts when the caller supplies no usable prefix.
+const DefaultNamePrefix = "amp"
+
+// letterPrefix is prepended when the sanitized project name does not start with
+// a letter (Salesforce developer names must). That keeps digit-leading names
+// like "11x" intact as "proj_11x" instead of stripping them down to "x".
+const letterPrefix = "proj"
+
+// SanitizeNamePrefix normalizes a caller-supplied prefix (typically the builder's
+// project or app name) into something Salesforce accepts at the front of a
+// developer name: letters, digits and single underscores, beginning with a letter.
+//
+//nolint:cyclop
+func SanitizeNamePrefix(prefix string) string {
+	var cleaned strings.Builder
+
+	for _, char := range prefix {
+		switch {
+		case char >= 'a' && char <= 'z',
+			char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9',
+			char == '_':
+			cleaned.WriteRune(char)
+		case char == '-' || char == ' ' || char == '.':
+			cleaned.WriteRune('_')
+		}
+	}
+
+	result := cleaned.String()
+	for strings.Contains(result, "__") {
+		result = strings.ReplaceAll(result, "__", "_")
+	}
+
+	result = strings.Trim(result, "_")
+	if result == "" {
+		return ""
+	}
+
+	if !isASCIILetter(rune(result[0])) {
+		return letterPrefix + "_" + result
+	}
+
+	return result
+}
+
+func isASCIILetter(char rune) bool {
+	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z')
+}
+
+// GenerateSubscriptionArtifactName builds the developer name shared by an
+// object's flow and its outbound message: "<prefix>_<Object>" (e.g. "acme_Account",
+// or "acme_My_Object_c" — custom-object suffixes like "__c" collapse, since
+// developer names cannot contain consecutive underscores).
+func GenerateSubscriptionArtifactName(prefix, objectName string) (string, error) {
+	if objectName == "" {
+		return "", errEmptyObjectName
+	}
+
+	cleanPrefix := SanitizeNamePrefix(prefix)
+	if cleanPrefix == "" {
+		cleanPrefix = DefaultNamePrefix
+	}
+
+	cleanObject := objectName
+	for strings.Contains(cleanObject, "__") {
+		cleanObject = strings.ReplaceAll(cleanObject, "__", "_")
+	}
+
+	// One underscore joins the two halves.
+	available := developerNameMaxLength - len(cleanObject) - 1
+	if len(cleanPrefix) > available {
+		cleanPrefix = strings.TrimRight(cleanPrefix[:available], "_")
+	}
+
+	return cleanPrefix + "_" + cleanObject, nil
+}

--- a/providers/salesforce/internal/crm/metadata/nameprefix_test.go
+++ b/providers/salesforce/internal/crm/metadata/nameprefix_test.go
@@ -1,0 +1,71 @@
+package metadata
+
+import (
+	"testing"
+)
+
+func TestSanitizeNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Already clean", "acme", "acme"},
+		{"Spaces and hyphens become underscores", "Acme Sales-Tools", "Acme_Sales_Tools"},
+		{"Dots become underscores", "acme.io", "acme_io"},
+		{"Illegal characters are dropped", "Acme! (EU) #1", "Acme_EU_1"},
+		{"Consecutive underscores collapse", "acme___sales", "acme_sales"},
+		{"Trailing underscores trimmed", "acme__", "acme"},
+		{"Digit-leading name is prefixed, not stripped", "11x", "proj_11x"},
+		{"Leading digits kept under proj_", "7shifts", "proj_7shifts"},
+		{"Digits-only name is prefixed", "123", "proj_123"},
+		{"Leading underscore dropped", "_acme", "acme"},
+		{"Digits kept when not leading", "acme2", "acme2"},
+		{"Punctuation only yields empty", "!!!", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := SanitizeNamePrefix(tt.input); got != tt.expected {
+				t.Errorf("SanitizeNamePrefix(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateSubscriptionArtifactName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prefix   string
+		object   string
+		expected string
+	}{
+		{"Standard object", "acme", "Lead", "acme_Lead"},
+		{"Custom object collapses consecutive underscores", "acme", "My_Object__c", "acme_My_Object_c"},
+		{"Prefix is sanitized, not rejected", "Acme Corp. (EU)", "Lead", "Acme_Corp_EU_Lead"},
+		{"Digit-leading project keeps its digits", "11x", "Lead", "proj_11x_Lead"},
+		{"Empty prefix falls back to default", "", "Account", "amp_Account"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GenerateSubscriptionArtifactName(tt.prefix, tt.object)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tt.expected {
+				t.Errorf("GenerateSubscriptionArtifactName(%q, %q) = %q, want %q",
+					tt.prefix, tt.object, got, tt.expected)
+			}
+		})
+	}
+}

--- a/providers/salesforce/internal/crm/metadata/outboundmessage.go
+++ b/providers/salesforce/internal/crm/metadata/outboundmessage.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/amp-labs/connectors/providers/salesforce/internal/crm/core"
 )
@@ -34,7 +33,7 @@ type OutboundMessageParams struct {
 
 	// Name is the outbound message developer name WITHOUT the object prefix
 	// (e.g., "amp_Lead"). The Metadata API addresses the component as
-	// "<ObjectName>.<Name>". Use GenerateOutboundMessageNameForSubscription()
+	// "<ObjectName>.<Name>". Use GenerateSubscriptionArtifactName()
 	// to generate this.
 	Name string
 
@@ -53,33 +52,10 @@ type OutboundMessageParams struct {
 	Fields []string
 }
 
-// GenerateOutboundMessageNameForSubscription returns the outbound message
-// developer name for a given Salesforce object. Developer names must not
-// contain consecutive underscores, so custom-object suffixes like "__c" are collapsed
-// (e.g. "My_Object__c" → "amp_My_Object_c").
-func GenerateOutboundMessageNameForSubscription(objectName string) (string, error) {
-	if objectName == "" {
-		return "", errEmptyObjectName
-	}
-
-	return "amp_" + sanitizeDeveloperName(objectName), nil
-}
-
 // OutboundMessageFullName returns the Metadata API full name of the outbound
 // message component, which is prefixed by the object it belongs to.
 func OutboundMessageFullName(objectName, outboundMessageName string) string {
 	return objectName + "." + outboundMessageName
-}
-
-// sanitizeDeveloperName converts an object API name into a string that is
-// valid inside a developer name: consecutive underscores collapse to one and
-// trailing underscores are trimmed.
-func sanitizeDeveloperName(name string) string {
-	for strings.Contains(name, "__") {
-		name = strings.ReplaceAll(name, "__", "_")
-	}
-
-	return strings.Trim(name, "_")
 }
 
 // ValidateOutboundMessageParams checks that all required fields are present.
@@ -152,10 +128,9 @@ func generateWorkflowXML(params OutboundMessageParams) (string, error) {
 		Xmlns: metadataXmlns,
 		OutboundMessages: []workflowOutboundMessageXML{
 			{
-				FullName:   params.Name,
-				APIVersion: core.APIVersion,
-				Description: "THIS IS AN AUTOMATED OUTBOUND MESSAGE. DO NOT EDIT. " +
-					"It delivers subscription events for the object to Ampersand.",
+				FullName:         params.Name,
+				APIVersion:       core.APIVersion,
+				Description:      "THIS IS AN AUTOMATED OUTBOUND MESSAGE. DO NOT EDIT.",
 				EndpointURL:      params.EndpointURL,
 				Fields:           fields,
 				IncludeSessionID: false,

--- a/providers/salesforce/internal/crm/metadata/outboundmessage_test.go
+++ b/providers/salesforce/internal/crm/metadata/outboundmessage_test.go
@@ -8,56 +8,6 @@ import (
 	"testing"
 )
 
-func TestGenerateOutboundMessageNameForSubscription(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		object    string
-		expected  string
-		expectErr bool
-	}{
-		{
-			name:     "Standard object",
-			object:   "Account",
-			expected: "amp_Account",
-		},
-		{
-			name:     "Custom object collapses consecutive underscores",
-			object:   "My_Object__c",
-			expected: "amp_My_Object_c",
-		},
-		{
-			name:      "Empty object name returns error",
-			object:    "",
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GenerateOutboundMessageNameForSubscription(tt.object)
-			if tt.expectErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got != tt.expected {
-				t.Errorf("GenerateOutboundMessageNameForSubscription(%q) = %q, want %q", tt.object, got, tt.expected)
-			}
-		})
-	}
-}
-
 func validOutboundMessageParams() OutboundMessageParams {
 	return OutboundMessageParams{
 		ObjectName:          "Account",


### PR DESCRIPTION
This is a purely additive PR, next in the stack building Salesforce Subscribe using Flows ([proposal](https://app.notion.com/p/Salesforce-Subscribe-via-Record-Triggered-Flow-Outbound-Messages-3cf1a75bd39681799c81f7fcb59278e2)). It sits on the outbound-message zip builder.

The flow-based Subscribe path deploys one Metadata API package: one `package.xml` listing `WorkflowOutboundMessage` and `Flow` members, plus `workflows/*.workflow` and `flows/*.flow`. This PR adds the flow half and the combined subscribe zip.

Subscribe wiring is still a later PR. This has been manually tested by the script at the top of the stack: deploying the combined package creates the flows and OMs in the org; Subscribe sends SOAP notifications to the OM endpoint; teardown deactivates/removes the flows and then the OMs.

**Test Cases**

- [x] Create, Update, CreateAndUpdate trigger conditions
- [x] with WatchFields set, without WatchFields set
- [x] Single object subscribe (Account), multiple object subscribe (Account + Contact)

<img width="1389" height="922" alt="Screenshot 2026-09-09 at 2 45 08 PM" src="https://github.com/user-attachments/assets/41e8e0bb-ae99-458a-bdea-992cbafd7506" />
