### PR TITLE
[ENG-4236] feat(salesforce): capture username post-auth via userinfo (3/8)

### DIFF
--- a/providers/salesforce.go
+++ b/providers/salesforce.go
@@ -200,6 +200,27 @@ func init() { // nolint:funlen
 						"found in Business Unit Setup within Salesforce Setup or Marketing Setup.",
 				},
 			},
+			// PostAuthentication metadata is fetched from Salesforce right after a
+			// connection is created (via Connector.GetPostAuthInfo) and stored on the
+			// connection's provider metadata. The username powers the flow-based
+			// Subscribe path: it becomes the outbound message's integration user.
+			// The lookup is best-effort — tokens minted without an identity scope
+			// (id/openid/profile/full) cannot call the userinfo endpoint, and
+			// GetPostAuthInfo degrades to an empty result rather than failing the
+			// connection.
+			// The username comes from the UserInfo endpoint's preferred_username
+			// response parameter ("Username of the queried user"):
+			// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm
+			// Scope requirements ("id — Allows access to the identity URL service"):
+			// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_tokens_scopes.htm
+			PostAuthentication: []MetadataItemPostAuthentication{
+				{
+					Name: "username",
+					ModuleDependencies: &ModuleDependencies{
+						ModuleSalesforceCRM: {},
+					},
+				},
+			},
 		},
 		ProviderAppMetadata: &ProviderAppMetadata{
 			ProviderParams: []MetadataItemInput{

--- a/providers/salesforce/authmetadata.go
+++ b/providers/salesforce/authmetadata.go
@@ -1,0 +1,87 @@
+package salesforce
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/common/logging"
+	"github.com/amp-labs/connectors/common/urlbuilder"
+)
+
+// PostAuthCatalogVarUsername is the catalog-var key under which GetPostAuthInfo
+// reports the connected user's Salesforce username. Callers (e.g. amp-labs/server)
+// persist it on the connection's provider metadata and can later feed it into
+// FlowConfig.IntegrationUsername without a fresh identity lookup.
+const PostAuthCatalogVarUsername = "username"
+
+var errUserinfoMissingUsername = errors.New("userinfo response carries no preferred_username")
+
+// GetPostAuthInfo is the connect-time hook the server calls right after OAuth.
+// It GETs /services/oauth2/userinfo and returns preferred_username as
+// CatalogVars["username"] for the server to persist on the connection.
+// Failures are swallowed (empty result + warning): a token without an
+// identity scope must not block creating the connection. Subscribe then
+// either uses that stored username as IntegrationUsername or falls back to
+// GetConnectedUsername.
+func (c *Connector) GetPostAuthInfo(ctx context.Context) (*common.PostAuthInfo, error) {
+	resp, username, err := c.getUserinfo(ctx)
+	if err != nil {
+		logging.Logger(ctx).WarnContext(ctx,
+			"could not resolve the connected user's username post-auth; "+
+				"continuing without it (token likely lacks an identity scope)",
+			"provider", c.Provider(),
+			"error", err,
+		)
+
+		return &common.PostAuthInfo{}, nil
+	}
+
+	return &common.PostAuthInfo{
+		RawResponse: resp,
+		CatalogVars: &map[string]string{
+			PostAuthCatalogVarUsername: username,
+		},
+	}, nil
+}
+
+// GetConnectedUsername is the subscribe-time lookup used only when
+// IntegrationUsername was not passed (no stored post-auth username). Same
+// userinfo endpoint as GetPostAuthInfo, but errors on failure — an outbound
+// message cannot deploy without an integration user.
+// Requires an identity scope (id/openid/profile/full).
+// https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm
+func (c *Connector) GetConnectedUsername(ctx context.Context) (string, error) {
+	_, username, err := c.getUserinfo(ctx)
+
+	return username, err
+}
+
+// getUserinfo calls /services/oauth2/userinfo and extracts preferred_username.
+func (c *Connector) getUserinfo(ctx context.Context) (*common.JSONHTTPResponse, string, error) {
+	url, err := urlbuilder.New(c.getModuleURL(), "services/oauth2/userinfo")
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := c.Client.Get(ctx, url.String())
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch userinfo: %w", err)
+	}
+
+	type userinfo struct {
+		PreferredUsername string `json:"preferred_username"`
+	}
+
+	info, err := common.UnmarshalJSON[userinfo](resp)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if info == nil || info.PreferredUsername == "" {
+		return nil, "", errUserinfoMissingUsername
+	}
+
+	return resp, info.PreferredUsername, nil
+}

--- a/providers/salesforce/authmetadata_test.go
+++ b/providers/salesforce/authmetadata_test.go
@@ -1,0 +1,129 @@
+package salesforce
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
+	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
+)
+
+const userinfoResponse = `{
+	"sub": "https://login.salesforce.com/id/00Dxx0000001gPFEAY/005xx000001SvokAAC",
+	"user_id": "005xx000001SvokAAC",
+	"organization_id": "00Dxx0000001gPFEAY",
+	"preferred_username": "integration@example.com",
+	"name": "Integration User"
+}`
+
+func TestGetConnectedUsername(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns preferred_username from userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Conditional{
+			Setup: mockserver.ContentJSON(),
+			If:    mockcond.Path("/services/oauth2/userinfo"),
+			Then:  mockserver.Response(http.StatusOK, []byte(userinfoResponse)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		username, err := connector.GetConnectedUsername(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if username != "integration@example.com" {
+			t.Errorf("username = %q, want integration@example.com", username)
+		}
+	})
+
+	t.Run("Errors when preferred_username is absent", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Fixed{
+			Setup:  mockserver.ContentJSON(),
+			Always: mockserver.Response(http.StatusOK, []byte(`{"sub": "only"}`)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		if _, err := connector.GetConnectedUsername(t.Context()); err == nil {
+			t.Error("expected error for missing preferred_username")
+		}
+	})
+}
+
+func TestGetPostAuthInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Reports the username as a catalog var", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockserver.Conditional{
+			Setup: mockserver.ContentJSON(),
+			If:    mockcond.Path("/services/oauth2/userinfo"),
+			Then:  mockserver.Response(http.StatusOK, []byte(userinfoResponse)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		info, err := connector.GetPostAuthInfo(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if info.CatalogVars == nil {
+			t.Fatal("expected catalog vars, got nil")
+		}
+
+		if got := (*info.CatalogVars)[PostAuthCatalogVarUsername]; got != "integration@example.com" {
+			t.Errorf("username catalog var = %q, want integration@example.com", got)
+		}
+	})
+
+	t.Run("Degrades to empty info when userinfo is scope-blocked", func(t *testing.T) {
+		t.Parallel()
+
+		// Tokens minted without an identity scope get a 403 from userinfo.
+		// GetPostAuthInfo must NOT propagate the error: the server treats a
+		// post-auth error as fatal for connection creation.
+		server := mockserver.Fixed{
+			Setup:  mockserver.ContentJSON(),
+			Always: mockserver.Response(http.StatusForbidden, []byte(`[{"errorCode":"FORBIDDEN"}]`)),
+		}.Server()
+		defer server.Close()
+
+		connector, err := constructTestConnector(server.URL)
+		if err != nil {
+			t.Fatalf("failed to construct connector: %v", err)
+		}
+
+		info, err := connector.GetPostAuthInfo(t.Context())
+		if err != nil {
+			t.Fatalf("expected graceful degradation, got error: %v", err)
+		}
+
+		if info == nil {
+			t.Fatal("expected empty PostAuthInfo, got nil")
+		}
+
+		if info.CatalogVars != nil {
+			t.Errorf("expected no catalog vars on failure, got %v", *info.CatalogVars)
+		}
+	})
+}


### PR DESCRIPTION
This is a purely additive PR in the stack building Salesforce Subscribe using Flows ([proposal](https://app.notion.com/p/Salesforce-Subscribe-via-Record-Triggered-Flow-Outbound-Messages-3cf1a75bd39681799c81f7fcb59278e2)). It sits on the OM + flow metadata builders.

Every outbound message needs an integration user — the Salesforce username whose field-level security the SOAP payload is evaluated under. This PR captures that username once at connect time so Subscribe does not have to ask for it. Subscribe can pass the stored value as `IntegrationUsername`. 

If it is missing (old connections, or connect-time lookup skipped), the connector uses `GetCurrentUsername` (same `userinfo` call) and errors if that fails — an OM cannot deploy without a user.

**Testing**
`GetCurrentUsername` has been tested live at the top of the stack via a script which ran the flow against my Salesforce org. 