### PR TITLE
[CON-3512] fix(acculynx): reconcile schemas with the live API (bare arrays and field fixes)

### DIFF
--- a/providers/acculynx/metadata/schemas.json
+++ b/providers/acculynx/metadata/schemas.json
@@ -34,7 +34,7 @@
         "acculynx/units-of-measure": {
           "displayName": "AccuLynx Units of Measure",
           "path": "/acculynx/units-of-measure",
-          "responseKey": "unitsOfMeasure",
+          "responseKey": "",
           "fields": {
             "friendlyName": {
               "displayName": "friendlyName",
@@ -240,8 +240,8 @@
           "path": "/company-settings/job-file-settings/document-folders",
           "responseKey": "items",
           "fields": {
-            "companyId": {
-              "displayName": "companyId",
+            "companyID": {
+              "displayName": "companyID",
               "valueType": "string",
               "providerType": "string"
             },
@@ -289,6 +289,11 @@
           "path": "/company-settings/job-file-settings/job-categories",
           "responseKey": "items",
           "fields": {
+            "categoryId": {
+              "displayName": "categoryId",
+              "valueType": "int",
+              "providerType": "integer"
+            },
             "id": {
               "displayName": "id",
               "valueType": "int",
@@ -306,13 +311,13 @@
           "path": "/company-settings/job-file-settings/photo-video-tags",
           "responseKey": "items",
           "fields": {
-            "id": {
-              "displayName": "id",
+            "tagId": {
+              "displayName": "tagId",
               "valueType": "string",
               "providerType": "string"
             },
-            "name": {
-              "displayName": "name",
+            "tagName": {
+              "displayName": "tagName",
               "valueType": "string",
               "providerType": "string"
             }
@@ -323,13 +328,13 @@
           "path": "/company-settings/job-file-settings/trade-types",
           "responseKey": "items",
           "fields": {
-            "name": {
-              "displayName": "name",
+            "id": {
+              "displayName": "id",
               "valueType": "string",
               "providerType": "string"
             },
-            "tradeId": {
-              "displayName": "tradeId",
+            "name": {
+              "displayName": "name",
               "valueType": "string",
               "providerType": "string"
             }
@@ -365,15 +370,15 @@
         "company-settings/job-file-settings/workflow-milestones": {
           "displayName": "Workflow Milestones",
           "path": "/company-settings/job-file-settings/workflow-milestones",
-          "responseKey": "items",
+          "responseKey": "",
           "fields": {
             "id": {
               "displayName": "id",
               "valueType": "int",
               "providerType": "integer"
             },
-            "name": {
-              "displayName": "name",
+            "milestone": {
+              "displayName": "milestone",
               "valueType": "singleSelect",
               "providerType": "string",
               "values": [
@@ -410,11 +415,6 @@
                   "displayValue": "Deleted"
                 }
               ]
-            },
-            "statuses": {
-              "displayName": "statuses",
-              "valueType": "other",
-              "providerType": "array"
             }
           }
         },
@@ -448,13 +448,8 @@
         "company-settings/location-settings/account-types": {
           "displayName": "Account Types",
           "path": "/company-settings/location-settings/account-types",
-          "responseKey": "items",
+          "responseKey": "",
           "fields": {
-            "IsActive": {
-              "displayName": "IsActive",
-              "valueType": "boolean",
-              "providerType": "boolean"
-            },
             "_link": {
               "displayName": "_link",
               "valueType": "string",
@@ -464,6 +459,11 @@
               "displayName": "id",
               "valueType": "string",
               "providerType": "string"
+            },
+            "isActive": {
+              "displayName": "isActive",
+              "valueType": "boolean",
+              "providerType": "boolean"
             },
             "name": {
               "displayName": "name",
@@ -566,11 +566,6 @@
               "valueType": "string",
               "providerType": "string"
             },
-            "customFieldDefinition": {
-              "displayName": "customFieldDefinition",
-              "valueType": "other",
-              "providerType": "object"
-            },
             "fieldType": {
               "displayName": "fieldType",
               "valueType": "singleSelect",
@@ -593,6 +588,11 @@
                   "displayValue": "Boolean"
                 }
               ]
+            },
+            "formattedValues": {
+              "displayName": "formattedValues",
+              "valueType": "other",
+              "providerType": "array"
             },
             "id": {
               "displayName": "id",
@@ -645,6 +645,11 @@
               "displayName": "primary",
               "valueType": "boolean",
               "providerType": "boolean"
+            },
+            "type": {
+              "displayName": "type",
+              "valueType": "string",
+              "providerType": "string"
             }
           }
         },
@@ -1038,11 +1043,6 @@
               "valueType": "string",
               "providerType": "string"
             },
-            "customFieldDefinition": {
-              "displayName": "customFieldDefinition",
-              "valueType": "other",
-              "providerType": "object"
-            },
             "fieldType": {
               "displayName": "fieldType",
               "valueType": "singleSelect",
@@ -1065,6 +1065,11 @@
                   "displayValue": "Boolean"
                 }
               ]
+            },
+            "formattedValues": {
+              "displayName": "formattedValues",
+              "valueType": "other",
+              "providerType": "array"
             },
             "id": {
               "displayName": "id",
@@ -1139,157 +1144,6 @@
               "displayName": "date",
               "valueType": "string",
               "providerType": "string"
-            },
-            "type": {
-              "displayName": "type",
-              "valueType": "singleSelect",
-              "providerType": "string",
-              "values": [
-                {
-                  "value": "Customer",
-                  "displayValue": "Customer"
-                },
-                {
-                  "value": "Job",
-                  "displayValue": "Job"
-                },
-                {
-                  "value": "Lead",
-                  "displayValue": "Lead"
-                },
-                {
-                  "value": "Measurement",
-                  "displayValue": "Measurement"
-                },
-                {
-                  "value": "Estimate",
-                  "displayValue": "Estimate"
-                },
-                {
-                  "value": "Order",
-                  "displayValue": "Order"
-                },
-                {
-                  "value": "Permit",
-                  "displayValue": "Permit"
-                },
-                {
-                  "value": "Payments",
-                  "displayValue": "Payments"
-                },
-                {
-                  "value": "Commission",
-                  "displayValue": "Commission"
-                },
-                {
-                  "value": "Precommission",
-                  "displayValue": "Precommission"
-                },
-                {
-                  "value": "ContractWorksheet",
-                  "displayValue": "ContractWorksheet"
-                },
-                {
-                  "value": "Supplement",
-                  "displayValue": "Supplement"
-                },
-                {
-                  "value": "File",
-                  "displayValue": "File"
-                },
-                {
-                  "value": "Unspecified",
-                  "displayValue": "Unspecified"
-                },
-                {
-                  "value": "CommunicationHistory",
-                  "displayValue": "CommunicationHistory"
-                },
-                {
-                  "value": "ContactNote",
-                  "displayValue": "ContactNote"
-                },
-                {
-                  "value": "JobContact",
-                  "displayValue": "JobContact"
-                },
-                {
-                  "value": "Contact",
-                  "displayValue": "Contact"
-                },
-                {
-                  "value": "JobMessage",
-                  "displayValue": "JobMessage"
-                },
-                {
-                  "value": "ContractWorksheetStatus",
-                  "displayValue": "ContractWorksheetStatus"
-                },
-                {
-                  "value": "MortgageCheck",
-                  "displayValue": "MortgageCheck"
-                },
-                {
-                  "value": "Measurements",
-                  "displayValue": "Measurements"
-                },
-                {
-                  "value": "Appointment",
-                  "displayValue": "Appointment"
-                },
-                {
-                  "value": "JobEmail",
-                  "displayValue": "JobEmail"
-                },
-                {
-                  "value": "JobPacket",
-                  "displayValue": "JobPacket"
-                },
-                {
-                  "value": "Account",
-                  "displayValue": "Account"
-                },
-                {
-                  "value": "Company",
-                  "displayValue": "Company"
-                },
-                {
-                  "value": "User",
-                  "displayValue": "User"
-                },
-                {
-                  "value": "FeatureManager",
-                  "displayValue": "FeatureManager"
-                },
-                {
-                  "value": "PermissionSettings",
-                  "displayValue": "PermissionSettings"
-                },
-                {
-                  "value": "LaborContact",
-                  "displayValue": "LaborContact"
-                },
-                {
-                  "value": "LaborOrder",
-                  "displayValue": "LaborOrder"
-                },
-                {
-                  "value": "Financing",
-                  "displayValue": "Financing"
-                },
-                {
-                  "value": "JobSignatureEmail",
-                  "displayValue": "JobSignatureEmail"
-                },
-                {
-                  "value": "JobPaymentRequest",
-                  "displayValue": "JobPaymentRequest"
-                },
-                {
-                  "value": "TextMessage",
-                  "displayValue": "TextMessage"
-                }
-              ]
             }
           }
         },

--- a/providers/acculynx/metadata_test.go
+++ b/providers/acculynx/metadata_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/amp-labs/connectors/common"
+	"github.com/amp-labs/connectors/providers/acculynx/metadata"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
+	"gotest.tools/v3/assert"
 )
 
 func TestListObjectMetadata(t *testing.T) { //nolint:funlen
@@ -229,4 +231,88 @@ func customFieldDefinitionsServer(fixture []byte) *httptest.Server {
 		},
 		Default: mockserver.ResponseString(http.StatusInternalServerError, `{"error":"unexpected"}`),
 	}.Server()
+}
+
+// TestSchemaFieldsMatchLivePayloads guards fieldFixesByObject in the metadata
+// generator. The AccuLynx spec names several properties differently from what
+// the API returns, declares some it never sends, and omits others it always
+// sends. ListObjectMetadata feeds the field picker behind
+// `optionalFieldsAuto: all`, so a regression here surfaces as wrong field names
+// in a builder's UI rather than as a test failure.
+//
+// Each expectation below was taken from a live response.
+func TestSchemaFieldsMatchLivePayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		object  string
+		present []string // returned by the API, so the schema must advertise them
+		absent  []string // never returned, so the schema must not advertise them
+	}{
+		{
+			object:  "company-settings/job-file-settings/photo-video-tags",
+			present: []string{"tagId", "tagName"},
+			absent:  []string{"id", "name"},
+		},
+		{
+			object:  "company-settings/job-file-settings/workflow-milestones",
+			present: []string{"id", "milestone"},
+			absent:  []string{"name", "statuses"},
+		},
+		{
+			object:  "company-settings/job-file-settings/trade-types",
+			present: []string{"id", "name"},
+			absent:  []string{"tradeId"},
+		},
+		{
+			object:  "company-settings/job-file-settings/document-folders",
+			present: []string{"companyID"},
+			absent:  []string{"companyId"},
+		},
+		{
+			object:  "company-settings/location-settings/account-types",
+			present: []string{"isActive"},
+			absent:  []string{"IsActive"},
+		},
+		{
+			object:  "company-settings/job-file-settings/job-categories",
+			present: []string{"id", "categoryId"},
+		},
+		{
+			object:  "contacts/email-addresses",
+			present: []string{"address", "type"},
+		},
+		{
+			object:  "contacts/custom-fields",
+			present: []string{"values", "formattedValues"},
+			absent:  []string{"customFieldDefinition"},
+		},
+		{
+			object:  "jobs/custom-fields",
+			present: []string{"values", "formattedValues"},
+			absent:  []string{"customFieldDefinition"},
+		},
+		{
+			object:  "jobs/history",
+			present: []string{"action", "date", "createdBy"},
+			absent:  []string{"type"},
+		},
+	}
+
+	for _, tt := range tests {
+		result, err := metadata.Schemas.Select(common.ModuleRoot, []string{tt.object})
+		assert.NilError(t, err)
+
+		fields := result.Result[tt.object].Fields
+
+		for _, name := range tt.present {
+			_, ok := fields[name]
+			assert.Assert(t, ok, "%s: expected field %q to be advertised", tt.object, name)
+		}
+
+		for _, name := range tt.absent {
+			_, ok := fields[name]
+			assert.Assert(t, !ok, "%s: field %q is never returned by AccuLynx", tt.object, name)
+		}
+	}
 }

--- a/providers/acculynx/read_test.go
+++ b/providers/acculynx/read_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockcond"
 	"github.com/amp-labs/connectors/test/utils/mockutils/mockserver"
 	"github.com/amp-labs/connectors/test/utils/testconn"
+	"gotest.tools/v3/assert"
 )
 
 //go:embed test/read/users-first-page.json
@@ -1120,7 +1121,7 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 			},
 		},
 		{
-			Name: "Read acculynx/units-of-measure honours custom responseKey",
+			Name: "Read acculynx/units-of-measure parses a bare array response",
 			Input: common.ReadParams{
 				ObjectName: "acculynx/units-of-measure",
 				Fields:     connectors.Fields("id", "name"),
@@ -1154,6 +1155,34 @@ func TestRead(t *testing.T) { //nolint:funlen,maintidx
 				return constructTestReadConnector(tt.Server.URL)
 			})
 		})
+	}
+}
+
+// TestBareArrayObjectsResolveToEmptyResponseKey guards the generator's
+// bareArrayObjects override. The AccuLynx spec declares a wrapper object for
+// these three, but the live API answers with a top-level array, so their
+// records key must be the empty bare-array convention. Without this, dropping
+// an entry from the override map would only surface as a runtime
+// "key not found" against the live API.
+func TestBareArrayObjectsResolveToEmptyResponseKey(t *testing.T) {
+	t.Parallel()
+
+	connector, err := constructTestReadConnector("http://localhost")
+	assert.NilError(t, err)
+
+	tests := []struct {
+		object string
+		want   string
+	}{
+		{"acculynx/units-of-measure", ""},
+		{"company-settings/job-file-settings/workflow-milestones", ""},
+		{"company-settings/location-settings/account-types", ""},
+		// Control: the spec describes countries the same way, but it genuinely wraps.
+		{"acculynx/countries", "items"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, connector.arrayFieldName(tt.object), tt.want, tt.object)
 	}
 }
 

--- a/providers/acculynx/test/read/units-of-measure.json
+++ b/providers/acculynx/test/read/units-of-measure.json
@@ -1,12 +1,12 @@
-{
-  "unitsOfMeasure": [
-    {
-      "id": "EA",
-      "name": "Each"
-    },
-    {
-      "id": "SF",
-      "name": "Square Feet"
-    }
-  ]
-}
+[
+  {
+    "id": "2a7a0d47-a669-49a7-8f5a-4c834bc2b2f0",
+    "name": "BAG",
+    "friendlyName": "Bag"
+  },
+  {
+    "id": "7b087d4f-df5c-4533-9bd2-62dba5c72b28",
+    "name": "BD",
+    "friendlyName": "Bundle"
+  }
+]

--- a/scripts/openapi/acculynx/metadata/main.go
+++ b/scripts/openapi/acculynx/metadata/main.go
@@ -107,6 +107,143 @@ var displayNameOverride = map[string]string{
 	"company-settings/location-settings/account-types":       "Account Types",
 }
 
+// bareArrayObjects lists objects whose list response is a bare JSON array. The
+// OpenAPI spec declares a wrapper object for each of them ("unitsOfMeasure" for
+// units-of-measure, "items" for the other two), but the live API returns the
+// array at the top level, so the generated responseKey names a key that is not
+// in the payload and the read fails with "key not found".
+//
+// Verified live (HTTP 200): /acculynx/units-of-measure, workflow-milestones and
+// account-types all return a top-level array, while /acculynx/countries — which
+// the spec describes identically — genuinely wraps in "items".
+//
+// An empty responseKey is the repo-wide bare-array convention: jsonquery's
+// ArrayRequired("") resolves to the current node.
+//
+//nolint:gochecknoglobals
+var bareArrayObjects = datautils.NewStringSet(
+	"acculynx/units-of-measure",
+	"company-settings/job-file-settings/workflow-milestones",
+	"company-settings/location-settings/account-types",
+)
+
+// responseKeyFor returns the object's records-array key, overriding the value
+// the spec produced for objects that actually answer with a bare array.
+func responseKeyFor(objectName, specResponseKey string) string {
+	if bareArrayObjects.Has(objectName) {
+		return ""
+	}
+
+	return specResponseKey
+}
+
+// fieldFixes reconciles an object's spec-declared properties with what the live
+// API actually returns.
+//
+//   - rename: the spec names a property differently from the payload. The
+//     field's type is unchanged, only its key, so the mapping is lossless.
+//   - drop:   declared by the spec but never present in a response.
+//   - add:    returned by every response but absent from the spec.
+type fieldFixes struct {
+	rename map[string]string
+	drop   datautils.StringSet
+	add    []metadatadef.Field
+}
+
+// fieldFixesByObject corrects field metadata for objects whose spec properties
+// disagree with the live API. Without these, ListObjectMetadata advertises
+// fields that do not exist and omits fields that do — and because
+// `optionalFieldsAuto: all` populates the field picker from that metadata, the
+// wrong names reach the builder's UI.
+//
+// Every entry was verified against live responses; the renames preserve the
+// spec's declared type because only the property name differs.
+//
+//nolint:gochecknoglobals
+var fieldFixesByObject = map[string]fieldFixes{
+	// The spec calls these "id"/"name"; the payload uses "tagId"/"tagName".
+	"company-settings/job-file-settings/photo-video-tags": {
+		rename: map[string]string{"id": "tagId", "name": "tagName"},
+	},
+	// The milestone's label ships as "milestone"; "statuses" is never returned.
+	"company-settings/job-file-settings/workflow-milestones": {
+		rename: map[string]string{"name": "milestone"},
+		drop:   datautils.NewStringSet("statuses"),
+	},
+	// The identifier ships as "id", not "tradeId".
+	"company-settings/job-file-settings/trade-types": {
+		rename: map[string]string{"tradeId": "id"},
+	},
+	// Capitalisation differs: the payload uses "companyID".
+	"company-settings/job-file-settings/document-folders": {
+		rename: map[string]string{"companyId": "companyID"},
+	},
+	// Capitalisation differs: the payload uses "isActive".
+	"company-settings/location-settings/account-types": {
+		rename: map[string]string{"IsActive": "isActive"},
+	},
+	// Job categories carry a "categoryId" alongside "id"; the spec omits it.
+	"company-settings/job-file-settings/job-categories": {
+		add: []metadatadef.Field{{Name: "categoryId", Type: "integer"}},
+	},
+	// Email addresses carry a "type" the read schema omits. It is added as a
+	// plain string rather than a select: the spec's only "type" enum lives on
+	// contactEmailAddress (the create shape) and lists Personal/Work/Other,
+	// but reads also return "Unspecified", so advertising that enum would
+	// declare a value set the API contradicts.
+	"contacts/email-addresses": {
+		add: []metadatadef.Field{{Name: "type", Type: "string"}},
+	},
+	// Custom-field values return "formattedValues" — the display-ready values —
+	// while the spec instead declares a "customFieldDefinition" object that the
+	// values endpoints never return.
+	"contacts/custom-fields": customFieldValueFixes(),
+	"jobs/custom-fields":     customFieldValueFixes(),
+	// History entries expose action/date/createdBy only; "type" is not returned.
+	"jobs/history": {
+		drop: datautils.NewStringSet("type"),
+	},
+}
+
+// customFieldValueFixes is shared by the contact and job custom-field value
+// objects, which return an identical record shape.
+func customFieldValueFixes() fieldFixes {
+	return fieldFixes{
+		drop: datautils.NewStringSet("customFieldDefinition"),
+		add:  []metadatadef.Field{{Name: "formattedValues", Type: "array"}},
+	}
+}
+
+// applyFieldFixes returns the object's fields with fieldFixesByObject applied.
+// Objects without an entry pass through untouched.
+func applyFieldFixes(objectName string, fields metadatadef.Fields) metadatadef.Fields {
+	fixes, ok := fieldFixesByObject[objectName]
+	if !ok {
+		return fields
+	}
+
+	fixed := make(metadatadef.Fields, len(fields))
+
+	for name, field := range fields {
+		if fixes.drop.Has(name) {
+			continue
+		}
+
+		if liveName, renamed := fixes.rename[name]; renamed {
+			field.Name = liveName
+			name = liveName
+		}
+
+		fixed[name] = field
+	}
+
+	for _, field := range fixes.add {
+		fixed[field.Name] = field
+	}
+
+	return fixed
+}
+
 //nolint:gochecknoglobals
 var allowedPaths = func() []string {
 	paths := make([]string, 0, len(objectEndpoints))
@@ -132,9 +269,9 @@ func main() {
 			continue
 		}
 
-		for _, field := range object.Fields {
+		for _, field := range applyFieldFixes(object.ObjectName, object.Fields) {
 			schemas.Add(common.ModuleRoot, object.ObjectName, object.DisplayName,
-				"/api/v2"+object.URLPath, object.ResponseKey,
+				"/api/v2"+object.URLPath, responseKeyFor(object.ObjectName, object.ResponseKey),
 				utilsopenapi.ConvertMetadataFieldToFieldMetadataMapV2(field), nil, object.Custom)
 		}
 


### PR DESCRIPTION
Reads for `acculynx/units-of-measure`, `workflow-milestones` and `account-types` fail with "key not found": the spec declares a wrapper object, but the live API returns a top-level array. The generator now overrides their `responseKey` to the empty bare-array convention (`/acculynx/countries` genuinely wraps and is untouched).

Also reconciles field metadata with what the API actually returns — renames spec-only property names to the payload names, drops fields never present, adds fields always present. Matters because `optionalFieldsAuto: all` builds the field picker straight from `ListObjectMetadata`.

# Tests

## Unit Test

<img width="1339" height="686" alt="image" src="https://github.com/user-attachments/assets/ff2cae07-333e-485d-b498-7483d86b5638" />
<img width="1339" height="907" alt="image" src="https://github.com/user-attachments/assets/a70374ad-a1a6-4e37-8fc7-39e81cf5a4b2" />
<img width="1339" height="907" alt="image" src="https://github.com/user-attachments/assets/6fda4c01-33dd-4461-b28c-2c80061777c9" />

## Live Test
<img width="1237" height="1008" alt="image" src="https://github.com/user-attachments/assets/aad99ed9-1153-41f0-b701-4f8694316635" />
<img width="1237" height="1008" alt="image" src="https://github.com/user-attachments/assets/1f964910-b088-4f3c-bd84-8df90352df2b" />
<img width="1237" height="1008" alt="image" src="https://github.com/user-attachments/assets/dd19c812-6295-421b-86f5-5ff65a943141" />
