### PR TITLE
[CON-3512] fix(acculynx): tolerate capitalised event wrapper casing in webhooks

### DIFF
--- a/providers/acculynx/subscriptionEvent.go
+++ b/providers/acculynx/subscriptionEvent.go
@@ -314,12 +314,43 @@ func (e SubscriptionEvent) objectWrapper() (map[string]any, error) {
 		key = objectWrapperJob
 	}
 
-	wrapper, ok := inner[key].(map[string]any)
+	wrapper, ok := lookupObjectWrapper(inner, key)
 	if !ok {
 		return nil, fmt.Errorf("%w: expected event.%s", errMissingObjectWrapper, key)
 	}
 
 	return wrapper, nil
+}
+
+// lookupObjectWrapper reads the object wrapper out of the inner event,
+// tolerating the key casing AccuLynx actually sends.
+//
+// Their schema and examples document lowercase ("event.job", "event.contact")
+// and every topic serialises it that way except job.contacts.primary_changed,
+// which sends "event.Job" — confirmed across repeated live deliveries against
+// a payload otherwise identical to their documented example. An exact-match
+// lookup drops the wrapper for that topic, so RecordId fails and the event
+// cannot be resolved to a record.
+//
+// Falling back to a case-insensitive match keeps that topic working and covers
+// the topics that can only be triggered from the AccuLynx UI, where the same
+// defect would otherwise surface as an unexplained webhook failure.
+func lookupObjectWrapper(inner map[string]any, key string) (map[string]any, bool) {
+	if wrapper, ok := inner[key].(map[string]any); ok {
+		return wrapper, true
+	}
+
+	for name, value := range inner {
+		if !strings.EqualFold(name, key) {
+			continue
+		}
+
+		wrapper, ok := value.(map[string]any)
+
+		return wrapper, ok
+	}
+
+	return nil, false
 }
 
 // VerifyWebhookMessage always returns true. AccuLynx's docs reference a

--- a/providers/acculynx/subscriptionEvent_test.go
+++ b/providers/acculynx/subscriptionEvent_test.go
@@ -471,3 +471,66 @@ func TestSubscriptionEvent_RecordId_CustomFieldStatusChanged_NoParentID(t *testi
 		})
 	}
 }
+
+// Real production payload captured live for job.contacts.primary_changed.
+//
+// AccuLynx serialises this topic's wrapper as "Job" — capitalised — while its
+// schema, its documented example and every other topic use lowercase "job".
+// Captured across repeated live deliveries; the payload is otherwise identical
+// to the documented example, so only the key casing differs. Before the
+// case-insensitive wrapper lookup this returned errMissingObjectWrapper and the
+// event could not be resolved to a record.
+func TestSubscriptionEvent_RealPayload_JobContactsPrimaryChanged_CapitalisedWrapper(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		"topicName":      "job.contacts.primary_changed",
+		"eventDateTime":  "2026-09-01T09:24:08.4639561Z",
+		"eventId":        "cd9ac00c-fe90-4dbb-9902-64b2137a20d2",
+		"subscriptionId": "b76074e4-e7b1-4f40-8f22-dc4506ce0b7c",
+		"event": map[string]any{
+			"Job": map[string]any{
+				"id": "0a7a5afa-e0d6-4cd8-9e1f-0f443726fa49",
+				"jobContact": map[string]any{
+					"id":        "ad941b32-d24e-42b1-98ba-df27be30e329",
+					"isPrimary": true,
+					"contact": map[string]any{
+						"id": "62546ee3-6915-40d4-90f5-a5658388d416",
+					},
+				},
+				"_link": "https://api.acculynx.com/api/v2/jobs/0a7a5afa-e0d6-4cd8-9e1f-0f443726fa49",
+			},
+		},
+	}
+
+	obj, err := evt.ObjectName()
+	assert.NilError(t, err)
+	assert.Equal(t, obj, objectJobs)
+
+	rid, err := evt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, rid, "0a7a5afa-e0d6-4cd8-9e1f-0f443726fa49")
+
+	fields, err := evt.UpdatedFields()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, fields, []string{"contacts"})
+}
+
+// The documented lowercase spelling must keep working — the case-insensitive
+// lookup is a fallback, not a replacement.
+func TestSubscriptionEvent_LowercaseWrapperStillResolves(t *testing.T) {
+	t.Parallel()
+
+	evt := SubscriptionEvent{
+		"topicName": "job.contacts.primary_changed",
+		"event": map[string]any{
+			"job": map[string]any{
+				"id": "5ac46861-75ae-45fe-b512-ff8d85ce8ab3",
+			},
+		},
+	}
+
+	rid, err := evt.RecordId()
+	assert.NilError(t, err)
+	assert.Equal(t, rid, "5ac46861-75ae-45fe-b512-ff8d85ce8ab3")
+}


### PR DESCRIPTION
`job.contacts.primary_changed` webhooks cannot be resolved to a record: AccuLynx documents the event wrapper lowercase (`event.job`) and sends it that way for every topic except this one, which sends `event.Job`. The exact-match lookup dropped the wrapper, so `RecordId()` failed.

Fix: `lookupObjectWrapper` tries the exact key first and falls back to a case-insensitive match. All working topics are unchanged. Unit test uses the real payload captured from repeated live deliveries.

# Tests

## Unit Test

<img width="1339" height="907" alt="image" src="https://github.com/user-attachments/assets/1fcc7649-7ca0-4d2b-8cdd-f0c24ea96a29" />
<img width="1339" height="907" alt="image" src="https://github.com/user-attachments/assets/9e1f5399-b4a4-4624-ba92-e5bfa1a39c7e" />
<img width="1339" height="907" alt="image" src="https://github.com/user-attachments/assets/ff3a9daf-5d7c-4174-8fb1-8cc9deada9c4" />
